### PR TITLE
debugged encodeErrorCheck()

### DIFF
--- a/BPTC19696.cpp
+++ b/BPTC19696.cpp
@@ -268,6 +268,13 @@ void CBPTC19696::encodeExtractData(const unsigned char* in) const
 // Check each row with a Hamming (15,11,3) code and each column with a Hamming (13,9,3) code
 void CBPTC19696::encodeErrorCheck()
 {
+	
+	// Run through each of the 9 rows containing data
+	for (unsigned int r = 0U; r < 9U; r++) {
+		unsigned int pos = (r * 15U) + 1U;
+		CHamming::encode15113(m_deInterData + pos);
+	}
+	
 	// Run through each of the 15 columns
 	bool col[13U];
 	for (unsigned int c = 0U; c < 15U; c++) {
@@ -284,12 +291,6 @@ void CBPTC19696::encodeErrorCheck()
 			m_deInterData[pos] = col[a];
 			pos = pos + 15U;
 		}
-	}
-
-	// Run through each of the 9 rows containing data
-	for (unsigned int r = 0U; r < 9U; r++) {
-		unsigned int pos = (r * 15U) + 1U;
-		CHamming::encode15113(m_deInterData + pos);
 	}
 }
 


### PR DESCRIPTION
First you have to encode the raws. Otherwise the hamming-code for the last 4 columns (column-hamming of raw-hamming) could not computed.