### PR TITLE
Clear line with URcall while going to LISTENING mode

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -135,7 +135,7 @@ void CHD44780::clearDStar()
 		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
 
 		::lcdPosition(m_fd, 0, 2);
-		::lcdPrintf(m_fd, "%.*s", m_cols, "");
+		::lcdPrintf(m_fd, "%.*s", m_cols, "        ");
 	} else {
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);


### PR DESCRIPTION
With a 20x4 LCD MMDVMHost writes URCall to the third line. After end of transmission this line is not cleared while line two shows "LISTENING". This change puts 8 spaces to clear the third line immideately.