### PR TITLE
Display Callsign on IDLE Display

### DIFF
--- a/Display.h
+++ b/Display.h
@@ -28,7 +28,7 @@ public:
 
   virtual bool open() = 0;
 
-  virtual void setIdle() = 0;
+  virtual void setIdle(const char* callsign) = 0;
 
   virtual void setLockout() = 0;
   virtual void setError(const char* text) = 0;

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -63,12 +63,12 @@ bool CHD44780::open()
 	return true;
 }
 
-void CHD44780::setIdle()
+void CHD44780::setIdle(const char* callsign)
 {
 	::lcdClear(m_fd);
 
 	::lcdPosition(m_fd, 0, 0);
-	::lcdPuts(m_fd, "MMDVM");
+	::lcdPrintf(m_fd, "MMDVM %s", callsign);
 
 	::lcdPosition(m_fd, 0, 1);
 	::lcdPuts(m_fd, "Idle");

--- a/HD44780.h
+++ b/HD44780.h
@@ -32,7 +32,7 @@ public:
 
   virtual bool open();
 
-  virtual void setIdle();
+  virtual void setIdle(const char* callsign);
 
   virtual void setError(const char* text);
   virtual void setLockout();

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -692,7 +692,7 @@ void CMMDVMHost::setMode(unsigned char mode, bool logging)
 		if (m_mode == MODE_DMR && m_duplex)
 			m_modem->writeDMRStart(false);
 		m_modem->setMode(MODE_IDLE);
-                std::string callsign = m_conf.getCallsign();
+		std::string callsign = m_conf.getCallsign();
 		m_display->setIdle(callsign.c_str());
 		m_mode = MODE_IDLE;
 		m_modeTimer.stop();

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -692,7 +692,8 @@ void CMMDVMHost::setMode(unsigned char mode, bool logging)
 		if (m_mode == MODE_DMR && m_duplex)
 			m_modem->writeDMRStart(false);
 		m_modem->setMode(MODE_IDLE);
-		m_display->setIdle();
+                std::string callsign = m_conf.getCallsign();
+		m_display->setIdle(callsign.c_str());
 		m_mode = MODE_IDLE;
 		m_modeTimer.stop();
 		break;

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -617,6 +617,8 @@ void CMMDVMHost::setMode(unsigned char mode, bool logging)
 	assert(m_modem != NULL);
 	assert(m_display != NULL);
 
+	std::string callsign = m_conf.getCallsign();
+
 	switch (mode) {
 	case MODE_DSTAR:
 		if (logging)
@@ -692,7 +694,6 @@ void CMMDVMHost::setMode(unsigned char mode, bool logging)
 		if (m_mode == MODE_DMR && m_duplex)
 			m_modem->writeDMRStart(false);
 		m_modem->setMode(MODE_IDLE);
-		std::string callsign = m_conf.getCallsign();
 		m_display->setIdle(callsign.c_str());
 		m_mode = MODE_IDLE;
 		m_modeTimer.stop();

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -48,12 +48,12 @@ bool CNextion::open()
 	::sprintf(command, "dim=%u", m_brightness);
 	sendCommand(command);
 
-	setIdle();
+	setIdle("");
 
 	return true;
 }
 
-void CNextion::setIdle()
+void CNextion::setIdle(const char* callsign)
 {
 	sendCommand("page MMDVM");
 

--- a/Nextion.h
+++ b/Nextion.h
@@ -32,7 +32,7 @@ public:
 
   virtual bool open();
 
-  virtual void setIdle();
+  virtual void setIdle(const char* callsign);
 
   virtual void setError(const char* text);
   virtual void setLockout();

--- a/NullDisplay.cpp
+++ b/NullDisplay.cpp
@@ -31,7 +31,7 @@ bool CNullDisplay::open()
 	return true;
 }
 
-void CNullDisplay::setIdle()
+void CNullDisplay::setIdle(const char* callsign)
 {
 }
 

--- a/NullDisplay.h
+++ b/NullDisplay.h
@@ -31,7 +31,7 @@ public:
 
   virtual bool open();
 
-  virtual void setIdle();
+  virtual void setIdle(const char* callsign);
 
   virtual void setError(const char* text);
   virtual void setLockout();

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -71,12 +71,12 @@ bool CTFTSerial::open()
 
 	setForeground(COLOUR_BLACK);
 
-	setIdle();
+	setIdle("");
 
 	return true;
 }
 
-void CTFTSerial::setIdle()
+void CTFTSerial::setIdle(const char* callsign)
 {
 	// Clear the screen
 	clearScreen();

--- a/TFTSerial.h
+++ b/TFTSerial.h
@@ -32,7 +32,7 @@ public:
 
   virtual bool open();
 
-  virtual void setIdle();
+  virtual void setIdle(const char* callsign);
 
   virtual void setError(const char* text);
   virtual void setLockout();


### PR DESCRIPTION
Some modifications to the display code in order to display the configured callsign of the HotSpot on the (LCD) Idle screen.