### PR TITLE
Add callsign and DMR id to displays idle screen

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -27,9 +27,11 @@
 
 const char* LISTENING = "Listening                                      ";
 
-CHD44780::CHD44780(unsigned int rows, unsigned int cols, const std::vector<unsigned int>& pins) :
+CHD44780::CHD44780(unsigned int rows, unsigned int cols, const char* callsign, unsigned int dmrid, const std::vector<unsigned int>& pins) :
 m_rows(rows),
 m_cols(cols),
+m_callsign(callsign),
+m_dmrid(dmrid),
 m_rb(pins.at(0U)),
 m_strb(pins.at(1U)),
 m_d0(pins.at(2U)),
@@ -68,10 +70,10 @@ void CHD44780::setIdle()
 	::lcdClear(m_fd);
 
 	::lcdPosition(m_fd, 0, 0);
-	::lcdPuts(m_fd, "MMDVM");
+	::lcdPrintf(m_fd, "%-6s / %u", m_callsign, m_dmrid);
 
 	::lcdPosition(m_fd, 0, 1);
-	::lcdPuts(m_fd, "Idle");
+	::lcdPuts(m_fd, "MMDVM Idle");
 }
 
 void CHD44780::setError(const char* text)

--- a/HD44780.h
+++ b/HD44780.h
@@ -27,7 +27,7 @@
 class CHD44780 : public IDisplay
 {
 public:
-  CHD44780(unsigned int rows, unsigned int cols, const std::vector<unsigned int>& pins);
+  CHD44780(unsigned int rows, unsigned int cols, const char* callsign, unsigned int dmrid, const std::vector<unsigned int>& pins);
   virtual ~CHD44780();
 
   virtual bool open();
@@ -54,6 +54,8 @@ public:
 private:
 	unsigned int m_rows;
 	unsigned int m_cols;
+	const char*  m_callsign;
+	unsigned int m_dmrid;
 	unsigned int m_rb;
 	unsigned int m_strb;
 	unsigned int m_d0;

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -567,6 +567,8 @@ void CMMDVMHost::readParams()
 void CMMDVMHost::createDisplay()
 {
 	std::string type = m_conf.getDisplay();
+	std::string callsign = m_conf.getCallsign();
+	unsigned int dmrid   = m_conf.getDMRId();
 
 	LogInfo("Display Parameters");
 	LogInfo("    Type: %s", type.c_str());
@@ -586,7 +588,7 @@ void CMMDVMHost::createDisplay()
 		LogInfo("    Port: %s", port.c_str());
 		LogInfo("    Brightness: %u", brightness);
 
-		m_display = new CNextion(port, brightness);
+		m_display = new CNextion(callsign.c_str(), dmrid, port, brightness);
 #if defined(HD44780)
 	} else if (type == "HD44780") {
 		unsigned int rows    = m_conf.getHD44780Rows();
@@ -598,7 +600,7 @@ void CMMDVMHost::createDisplay()
 			LogInfo("    Columns: %u", columns);
 			LogInfo("    Pins: %u,%u,%u,%u,%u,%u", pins.at(0U), pins.at(1U), pins.at(2U), pins.at(3U), pins.at(4U), pins.at(5U));
 
-			m_display = new CHD44780(rows, columns, pins);
+			m_display = new CHD44780(rows, columns, callsign.c_str(), dmrid, pins);
 		}
 #endif
 	} else {

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -23,7 +23,9 @@
 #include <cassert>
 #include <cstring>
 
-CNextion::CNextion(const std::string& port, unsigned int brightness) :
+CNextion::CNextion(const char* callsign, unsigned int dmrid, const std::string& port, unsigned int brightness) :
+m_callsign(callsign),
+m_dmrid(dmrid),
 m_serial(port, SERIAL_9600),
 m_brightness(brightness)
 {
@@ -57,7 +59,11 @@ void CNextion::setIdle()
 {
 	sendCommand("page MMDVM");
 
-	sendCommand("t0.txt=\"IDLE\"");
+	char command[30];
+	::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign, m_dmrid);
+
+	sendCommand(command);
+	sendCommand("t1.txt=\"MMDVM IDLE\"");
 }
 
 void CNextion::setError(const char* text)

--- a/Nextion.h
+++ b/Nextion.h
@@ -27,7 +27,7 @@
 class CNextion : public IDisplay
 {
 public:
-  CNextion(const std::string& port, unsigned int brightness);
+  CNextion(const char* callsign, unsigned int dmrid, const std::string& port, unsigned int brightness);
   virtual ~CNextion();
 
   virtual bool open();
@@ -52,6 +52,8 @@ public:
   virtual void close();
 
 private:
+  const char*  m_callsign;
+  unsigned int m_dmrid;
   CSerialController m_serial;
   unsigned int      m_brightness;
 


### PR DESCRIPTION
Sorry for the confusion. This is the pull request from my branch. It includes display of DMR ID and callsgin on the IDLE screen of HD44780 and Nextion LCDs.