### PR TITLE
Add source identifier

### DIFF
--- a/DStarControl.cpp
+++ b/DStarControl.cpp
@@ -203,7 +203,7 @@ bool CDStarControl::writeModem(unsigned char *data)
 		m_rfState = RS_RF_AUDIO;
 
 		if (m_netState == RS_NET_IDLE)
-			m_display->writeDStar((char*)my1, (char*)my2, (char*)your);
+			m_display->writeDStar((char*)my1, (char*)my2, (char*)your, "R");
 
 		LogMessage("D-Star, received RF header from %8.8s/%4.4s to %8.8s", my1, my2, your);
 	} else if (type == TAG_EOT) {
@@ -374,7 +374,7 @@ bool CDStarControl::writeModem(unsigned char *data)
 			m_rfN = (m_rfN + 1U) % 21U;
 
 			if (m_netState == RS_NET_IDLE)
-				m_display->writeDStar((char*)my1, (char*)my2, (char*)your);
+				m_display->writeDStar((char*)my1, (char*)my2, (char*)your, "R");
 
 			LogMessage("D-Star, received RF late entry from %8.8s/%4.4s to %8.8s", my1, my2, your);
 		}
@@ -491,7 +491,7 @@ void CDStarControl::writeNetwork()
 #endif
 		m_netState = RS_NET_AUDIO;
 
-		m_display->writeDStar((char*)my1, (char*)my2, (char*)your);
+		m_display->writeDStar((char*)my1, (char*)my2, (char*)your, "N");
 
 		LogMessage("D-Star, received network header from %8.8s/%4.4s to %8.8s", my1, my2, your);
 	} else if (type == TAG_EOT) {

--- a/Display.h
+++ b/Display.h
@@ -33,7 +33,7 @@ public:
   virtual void setLockout() = 0;
   virtual void setError(const char* text) = 0;
 
-  virtual void writeDStar(const char* my1, const char* my2, const char* your) = 0;
+  virtual void writeDStar(const char* my1, const char* my2, const char* your, const char* type) = 0;
   virtual void clearDStar() = 0;
 
   virtual void writeDMR(unsigned int slotNo, unsigned int srdId, bool group, unsigned int dstId, const char* type) = 0;

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -107,7 +107,7 @@ void CHD44780::setLockout()
 	m_dmr = false;
 }
 
-void CHD44780::writeDStar(const char* my1, const char* my2, const char* your)
+void CHD44780::writeDStar(const char* my1, const char* my2, const char* your, const char* type)
 {
 	assert(my1 != NULL);
 	assert(my2 != NULL);
@@ -121,7 +121,7 @@ void CHD44780::writeDStar(const char* my1, const char* my2, const char* your)
 	if (m_rows > 2U) {
 		char buffer[40U];
 
-		::sprintf(buffer, "%.8s/%.4s >", my1, my2);
+		::sprintf(buffer, "%s %.8s/%.4s >", type, my1, my2);
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
 

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -130,7 +130,7 @@ void CHD44780::writeDStar(const char* my1, const char* my2, const char* your, co
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
 	} else {
 		char buffer[40U];
-		::sprintf(buffer, "%.8s/%.4s > %.8s", my1, my2, your);
+		::sprintf(buffer, "%s %.8s/%.4s > %.8s", type, my1, my2, your);
 
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);

--- a/HD44780.h
+++ b/HD44780.h
@@ -37,7 +37,7 @@ public:
   virtual void setError(const char* text);
   virtual void setLockout();
 
-  virtual void writeDStar(const char* my1, const char* my2, const char* your);
+  virtual void writeDStar(const char* my1, const char* my2, const char* your, const char* type);
   virtual void clearDStar();
 
   virtual void writeDMR(unsigned int slotNo, unsigned int srdId, bool group, unsigned int dstId, const char* type);

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -103,7 +103,7 @@ void CNextion::writeDStar(const char* my1, const char* my2, const char* your, co
 		sendCommand("page DStar");
 
 	char text[30U];
-	::sprintf(text, "t0.txt=\"%.8s/%4.4s\"", my1, my2);
+	::sprintf(text, "t0.txt=\"%s %.8s/%4.4s\"", type, my1, my2);
 	sendCommand(text);
 
 	::sprintf(text, "t1.txt=\"%.8s\"", your);

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -93,7 +93,7 @@ void CNextion::setLockout()
 	m_mode = MODE_LOCKOUT;
 }
 
-void CNextion::writeDStar(const char* my1, const char* my2, const char* your)
+void CNextion::writeDStar(const char* my1, const char* my2, const char* your, const char* type)
 {
 	assert(my1 != NULL);
 	assert(my2 != NULL);

--- a/Nextion.h
+++ b/Nextion.h
@@ -38,7 +38,7 @@ public:
   virtual void setError(const char* text);
   virtual void setLockout();
 
-  virtual void writeDStar(const char* my1, const char* my2, const char* your);
+  virtual void writeDStar(const char* my1, const char* my2, const char* your, const char* type);
   virtual void clearDStar();
 
   virtual void writeDMR(unsigned int slotNo, unsigned int srdId, bool group, unsigned int dstId, const char* type);

--- a/NullDisplay.cpp
+++ b/NullDisplay.cpp
@@ -43,7 +43,7 @@ void CNullDisplay::setLockout()
 {
 }
 
-void CNullDisplay::writeDStar(const char* my1, const char* my2, const char* your)
+void CNullDisplay::writeDStar(const char* my1, const char* my2, const char* your, const char* type)
 {
 }
 

--- a/NullDisplay.h
+++ b/NullDisplay.h
@@ -36,7 +36,7 @@ public:
   virtual void setError(const char* text);
   virtual void setLockout();
 
-  virtual void writeDStar(const char* my1, const char* my2, const char* your);
+  virtual void writeDStar(const char* my1, const char* my2, const char* your, const char* type);
   virtual void clearDStar();
 
   virtual void writeDMR(unsigned int slotNo, unsigned int srdId, bool group, unsigned int dstId, const char* type);

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -159,7 +159,7 @@ void CTFTSerial::writeDStar(const char* my1, const char* my2, const char* your, 
 	}
 
 	char text[30U];
-	::sprintf(text, "%.8s/%4.4s", my1, my2);
+	::sprintf(text, "%s %.8s/%4.4s", type, my1, my2);
 
 	gotoPosPixel(5U, 80U);
 	displayText(text);

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -142,7 +142,7 @@ void CTFTSerial::setLockout()
 	m_mode = MODE_LOCKOUT;
 }
 
-void CTFTSerial::writeDStar(const char* my1, const char* my2, const char* your)
+void CTFTSerial::writeDStar(const char* my1, const char* my2, const char* your, const char* type)
 {
 	assert(my1 != NULL);
 	assert(my2 != NULL);

--- a/TFTSerial.h
+++ b/TFTSerial.h
@@ -38,7 +38,7 @@ public:
   virtual void setError(const char* text);
   virtual void setLockout();
 
-  virtual void writeDStar(const char* my1, const char* my2, const char* your);
+  virtual void writeDStar(const char* my1, const char* my2, const char* your, const char* type);
   virtual void clearDStar();
 
   virtual void writeDMR(unsigned int slotNo, unsigned int srdId, bool group, unsigned int dstId, const char* type);


### PR DESCRIPTION
I added the output of a source identifier to the D-Star outputs. An "R" for local transmissions and an "N" for incoming network data just like the DMR output has. Tested with 4x20 and 2x16 LCD as well as Nextion.