### PR TITLE
Define display sizes

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -249,13 +249,16 @@ void CHD44780::writeFusion(const char* source, const char* dest)
 
 void CHD44780::clearFusion()
 {
-	if (m_rows > 2U) {
+	if (m_rows == 2U && m_cols == 16U) {
+		::lcdPosition(m_fd, 0, 1);
+		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
+	} else if (m_rows == 4U && m_cols == 20U) {
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
 
 		::lcdPosition(m_fd, 0, 2);
-		::lcdPrintf(m_fd, "%.*s", m_cols, "");
-	} else {
+		::lcdPrintf(m_fd, "%.*s", m_cols, "                    ");
+	} else if (m_rows == 2 && m_cols == 40U) {
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
 	}

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -226,9 +226,13 @@ void CHD44780::writeFusion(const char* source, const char* dest)
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPuts(m_fd, "System Fusion");
 
-	if (m_rows > 2U) {
-		char buffer[40U];
-
+	if (m_rows == 2U && m_cols == 16U) {
+		char buffer[16U];
+		::sprintf(buffer, "%.10s >", source);
+		::lcdPosition(m_fd, 0, 1);
+		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
+	} else if (m_rows == 4U && m_cols == 20U) {
+		char buffer[20U];
 		::sprintf(buffer, "%.10s >", source);
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
@@ -236,7 +240,7 @@ void CHD44780::writeFusion(const char* source, const char* dest)
 		::sprintf(buffer, "%.10s", dest);
 		::lcdPosition(m_fd, 0, 2);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
-	} else {
+	} else if (m_rows == 2 && m_cols == 40U) {
 		char buffer[40U];
 		::sprintf(buffer, "%.10s > %.10s", source, dest);
 

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -25,7 +25,7 @@
 #include <cstdio>
 #include <cassert>
 
-const char* LISTENING = "Listening                                      ";
+const char* LISTENING = "Listening                               ";
 
 CHD44780::CHD44780(unsigned int rows, unsigned int cols, const char* callsign, unsigned int dmrid, const std::vector<unsigned int>& pins) :
 m_rows(rows),
@@ -145,13 +145,16 @@ void CHD44780::writeDStar(const char* my1, const char* my2, const char* your, co
 
 void CHD44780::clearDStar()
 {
-	if (m_rows > 2U) {
+	if (m_rows == 2U && m_cols == 16U) {
+		::lcdPosition(m_fd, 0, 1);
+		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
+	} else if (m_rows == 4U && m_cols == 20U) {
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
 
 		::lcdPosition(m_fd, 0, 2);
-		::lcdPrintf(m_fd, "%.*s", m_cols, "        ");
-	} else {
+		::lcdPrintf(m_fd, "%.*s", m_cols, "                    ");
+	} else if (m_rows == 2 && m_cols == 40U) {
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
 	}

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -207,12 +207,39 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, unsign
 
 void CHD44780::clearDMR(unsigned int slotNo)
 {
-	if (slotNo == 1U) {
-		::lcdPosition(m_fd, 0, m_rows > 2U ? 1 : 0);
-		::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-	} else {
-		::lcdPosition(m_fd, 0, m_rows > 2U ? 2 : 1);
-		::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+	if (m_rows == 2U && m_cols == 16U) {
+		if (slotNo == 1U) {
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+		} else {
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+		}
+	} else if (m_rows == 4U && m_cols == 20U) {
+		if (slotNo == 1U) {
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+		} else {
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+
+			::lcdPosition(m_fd, 0, 2);
+			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+		}
+	} else if (m_rows == 2 && m_cols == 40U) {
+		if (slotNo == 1U) {
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+		} else {
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+		}
 	}
 }
 

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -201,33 +201,33 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, const 
 	if (m_rows == 2U && m_cols == 16U) {
 		char buffer[16U];
 		if (slotNo == 1U) {
-			::sprintf(buffer, "%s > %s%u", src, group ? "TG" : "", dstId);
+			::sprintf(buffer, "%s > %s%s", src, group ? "TG" : "", dst);
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
 		} else {
-			::sprintf(buffer, "%s > %s%u", src, group ? "TG" : "", dstId);
+			::sprintf(buffer, "%s > %s%s", src, group ? "TG" : "", dst);
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 		}
 	} else if (m_rows == 4U && m_cols == 20U) {
 		char buffer[20U];
 		if (slotNo == 1U) {
-			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::sprintf(buffer, "%s %s > %s%s", type, src, group ? "TG" : "", dst);
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
 		} else {
-			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::sprintf(buffer, "%s %s > %s%s", type, src, group ? "TG" : "", dst);
 			::lcdPosition(m_fd, 0, 2);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 		}
 	} else if (m_rows == 2U && m_cols == 40U) {
 		char buffer[40U];
 		if (slotNo == 1U) {
-			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::sprintf(buffer, "%s %s > %s%s", type, src, group ? "TG" : "", dst);
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
 		} else {
-			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::sprintf(buffer, "%s %s > %s%s", type, src, group ? "TG" : "", dst);
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 		}

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -206,24 +206,39 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, unsign
 		}
 	}
 
-	if (slotNo == 1U) {
-		char buffer[40U];
-		if (m_cols > 16U)
-			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
-		else
+	if (m_rows == 2U && m_cols == 16U) {
+		char buffer[16U];
+		if (slotNo == 1U) {
 			::sprintf(buffer, "%s > %s%u", src, group ? "TG" : "", dstId);
-
-		::lcdPosition(m_fd, 0, m_rows > 2U ? 1 : 0);
-		::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
-	} else {
-		char buffer[40U];
-		if (m_cols > 16U)
-			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
-		else
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
+		} else {
 			::sprintf(buffer, "%s > %s%u", src, group ? "TG" : "", dstId);
-
-		::lcdPosition(m_fd, 0, m_rows > 2U ? 2 : 1);
-		::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
+		}
+	} else if (m_rows == 4U && m_cols == 20U) {
+		char buffer[20U];
+		if (slotNo == 1U) {
+			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
+		} else {
+			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::lcdPosition(m_fd, 0, 2);
+			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
+		}
+	} else if (m_rows == 2 && m_cols == 40U) {
+		char buffer[40U];
+		if (slotNo == 1U) {
+			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
+		} else {
+			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
+			::lcdPosition(m_fd, 0, 1);
+			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
+		}
 	}
 
 	m_dmr = true;

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -119,9 +119,13 @@ void CHD44780::writeDStar(const char* my1, const char* my2, const char* your, co
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPuts(m_fd, "D-Star");
 
-	if (m_rows > 2U) {
-		char buffer[40U];
-
+	if (m_rows == 2U && m_cols == 16U) {
+		char buffer[16U];
+		::sprintf(buffer, "%s %.8s/%.4s", type, my1, my2);
+		::lcdPosition(m_fd, 0, 1);
+		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
+	} else if (m_rows == 4U && m_cols == 20U) {
+		char buffer[20U];
 		::sprintf(buffer, "%s %.8s/%.4s >", type, my1, my2);
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
@@ -129,10 +133,9 @@ void CHD44780::writeDStar(const char* my1, const char* my2, const char* your, co
 		::sprintf(buffer, "%.8s", your);
 		::lcdPosition(m_fd, 0, 2);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
-	} else {
+	} else if (m_rows == 2 && m_cols == 40U) {
 		char buffer[40U];
 		::sprintf(buffer, "%s %.8s/%.4s > %.8s", type, my1, my2, your);
-
 		::lcdPosition(m_fd, 0, 1);
 		::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
 	}

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -170,38 +170,30 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, unsign
 
 		if (m_rows == 2U && m_cols == 16U) {
 			if (slotNo == 1U) {
-				::lcdPosition(m_fd, 0, 0);
-				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			} else {
 				::lcdPosition(m_fd, 0, 0);
 				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
 
-				::lcdPosition(m_fd, 0, 1);
-				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			}
 		} else if (m_rows == 4U && m_cols == 20U) {
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPuts(m_fd, "DMR");
 			if (slotNo == 1U) {
-				::lcdPosition(m_fd, 0, 1);
-				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+				::lcdPosition(m_fd, 0, 2);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			} else {
 				::lcdPosition(m_fd, 0, 1);
 				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-
-				::lcdPosition(m_fd, 0, 2);
-				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			}
 		} else if (m_rows == 2U && m_cols == 40U) {
 			if (slotNo == 1U) {
-				::lcdPosition(m_fd, 0, 0);
-				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			} else {
 				::lcdPosition(m_fd, 0, 0);
 				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-
-				::lcdPosition(m_fd, 0, 1);
-				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			}
 		}
 	}
@@ -251,9 +243,6 @@ void CHD44780::clearDMR(unsigned int slotNo)
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
 		} else {
-			::lcdPosition(m_fd, 0, 0);
-			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 		}
@@ -262,9 +251,6 @@ void CHD44780::clearDMR(unsigned int slotNo)
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
 		} else {
-			::lcdPosition(m_fd, 0, 1);
-			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-
 			::lcdPosition(m_fd, 0, 2);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 		}
@@ -273,9 +259,6 @@ void CHD44780::clearDMR(unsigned int slotNo)
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
 		} else {
-			::lcdPosition(m_fd, 0, 0);
-			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 		}

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -192,7 +192,7 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, unsign
 				::lcdPosition(m_fd, 0, 2);
 				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 			}
-		} else if (m_rows == 2 && m_cols == 40U) {
+		} else if (m_rows == 2U && m_cols == 40U) {
 			if (slotNo == 1U) {
 				::lcdPosition(m_fd, 0, 0);
 				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
@@ -228,7 +228,7 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, unsign
 			::lcdPosition(m_fd, 0, 2);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 		}
-	} else if (m_rows == 2 && m_cols == 40U) {
+	} else if (m_rows == 2U && m_cols == 40U) {
 		char buffer[40U];
 		if (slotNo == 1U) {
 			::sprintf(buffer, "%s %s > %s%u", type, src, group ? "TG" : "", dstId);
@@ -268,7 +268,7 @@ void CHD44780::clearDMR(unsigned int slotNo)
 			::lcdPosition(m_fd, 0, 2);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
 		}
-	} else if (m_rows == 2 && m_cols == 40U) {
+	} else if (m_rows == 2U && m_cols == 40U) {
 		if (slotNo == 1U) {
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -168,17 +168,41 @@ void CHD44780::writeDMR(unsigned int slotNo, const char* src, bool group, unsign
 	if (!m_dmr) {
 		::lcdClear(m_fd);
 
-		if (m_rows > 2U) {
+		if (m_rows == 2U && m_cols == 16U) {
+			if (slotNo == 1U) {
+				::lcdPosition(m_fd, 0, 0);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+			} else {
+				::lcdPosition(m_fd, 0, 0);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+			}
+		} else if (m_rows == 4U && m_cols == 20U) {
 			::lcdPosition(m_fd, 0, 0);
 			::lcdPuts(m_fd, "DMR");
-		}
+			if (slotNo == 1U) {
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+			} else {
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
 
-		if (slotNo == 1U) {
-			::lcdPosition(m_fd, 0, m_rows > 2U ? 2 : 1);
-			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
-		} else {
-			::lcdPosition(m_fd, 0, m_rows > 2U ? 1 : 0);
-			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+				::lcdPosition(m_fd, 0, 2);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+			}
+		} else if (m_rows == 2 && m_cols == 40U) {
+			if (slotNo == 1U) {
+				::lcdPosition(m_fd, 0, 0);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+			} else {
+				::lcdPosition(m_fd, 0, 0);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+			}
 		}
 	}
 


### PR DESCRIPTION
I refactored the HD44780 code a little in order to have more structure on the various display sizes. After successful tests with a 2x40 LCD and a patched wiringPi by DL5APR I also added this display layout (besides 2x16 and 4x20).