### PR TITLE
Add support for the Adafruit 16 x 2

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -54,6 +54,10 @@ bool CHD44780::open()
 {
 	::wiringPiSetup();
 
+#ifdef ADAFRUIT_DISPLAY
+        adafruitLCDSetup();
+#endif
+
 	m_fd = ::lcdInit(m_rows, m_cols, 4, m_rb, m_strb, m_d0, m_d1, m_d2, m_d3, 0, 0, 0, 0);
 	if (m_fd == -1) {
 		LogError("Unable to open the HD44780");
@@ -66,6 +70,22 @@ bool CHD44780::open()
 
 	return true;
 }
+
+#ifdef ADAFRUIT_DISPLAY
+void CHD44780::adafruitLCDSetup()
+{
+    // The other control pins are initialised with lcdInit ()
+    ::mcp23017Setup (AF_BASE, MCP23017);
+
+    // Backlight LEDs, Only one color (RED)
+    pinMode (AF_RED,   OUTPUT);
+    digitalWrite (AF_RED,   LOW); // The colour outputs are inverted.
+
+    // Control signals
+    pinMode (AF_RW, OUTPUT);
+    digitalWrite (AF_RW, LOW);
+}
+#endif
 
 void CHD44780::setIdle()
 {

--- a/HD44780.h
+++ b/HD44780.h
@@ -24,6 +24,16 @@
 #include <string>
 #include <vector>
 
+#include <mcp23017.h>
+
+// Defines for the Adafruit Pi LCD interface board
+#ifdef ADAFRUIT_DISPLAY
+#define AF_BASE         100
+#define AF_RED          (AF_BASE + 6)
+#define AF_RW           (AF_BASE + 14)
+#define MCP23017        0x20
+#endif
+
 class CHD44780 : public IDisplay
 {
 public:
@@ -61,6 +71,11 @@ private:
 	unsigned int m_d3;
 	int          m_fd;
 	bool         m_dmr;
+
+#ifdef ADAFRUIT_DISPLAY
+    void adafruitLCDSetup();
+#endif
+
 };
 
 #endif

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -85,7 +85,9 @@ Brightness=50
 Rows=2
 Columns=16
 # rs, strb, d0, d1, d2, d3
-Pins=11,10,0,1,2,3
+# Pins=11,10,0,1,2,3
+# Adafruit i2c HD44780
+Pins=115,113,112,111,110,109
 
 [Nextion]
 Port=/dev/ttyAMA0

--- a/Makefile.Pi
+++ b/Makefile.Pi
@@ -2,15 +2,15 @@
 
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -DHD44780 -DADAFRUIT -I/usr/local/include
+CFLAGS  = -g -O3 -Wall -std=c++0x -DHD44780 -DADAFRUIT_DISPLAY -I/usr/local/include
 LIBS    = -lwiringPi -lwiringPiDev
 LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \
-		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLC.o DMRShortLC.o \
-		DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o Modem.o \
-		NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Timer.o Trellis.o UDPSocket.o Utils.o YSFControl.o YSFConvolution.o \
-		YSFFICH.o YSFParrot.o YSFPayload.o
+		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
+		DMRShortLC.o DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o \
+		Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Timer.o Trellis.o UDPSocket.o Utils.o YSFControl.o \
+		YSFConvolution.o YSFFICH.o YSFParrot.o YSFPayload.o
 
 all:		MMDVMHost
 

--- a/Makefile.Pi
+++ b/Makefile.Pi
@@ -2,15 +2,15 @@
 
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -DHD44780 -I/usr/local/include
+CFLAGS  = -g -O3 -Wall -std=c++0x -DHD44780 -DADAFRUIT -I/usr/local/include
 LIBS    = -lwiringPi -lwiringPiDev
 LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \
-		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
-		DMRShortLC.o DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o \
-		Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Timer.o Trellis.o UDPSocket.o Utils.o YSFControl.o \
-		YSFConvolution.o YSFFICH.o YSFParrot.o YSFPayload.o
+		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLC.o DMRShortLC.o \
+		DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o Modem.o \
+		NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Timer.o Trellis.o UDPSocket.o Utils.o YSFControl.o YSFConvolution.o \
+		YSFFICH.o YSFParrot.o YSFPayload.o
 
 all:		MMDVMHost
 

--- a/Makefile.Pi.Adafruit
+++ b/Makefile.Pi.Adafruit
@@ -1,8 +1,8 @@
 # This makefile is for use with the Raspberry Pi when using an HD44780 compatible display. The wiringpi library is needed.
-
+# Support for the Adafruit i2c 16 x 2 RGB LCD Pi Plate
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -DHD44780 -I/usr/local/include
+CFLAGS  = -g -O3 -Wall -std=c++0x -DHD44780 -DADAFRUIT_DISPLAY -I/usr/local/include
 LIBS    = -lwiringPi -lwiringPiDev
 LDFLAGS = -g -L/usr/local/lib
 


### PR DESCRIPTION
The Adafruit i2c 16 x 2 RGB LCD Pi Plate uses a MCP23017 as a GPIO expander.

73, Steve N4IRS