### PR TITLE
remove compiler warning

### DIFF
--- a/AMBEFEC.cpp
+++ b/AMBEFEC.cpp
@@ -686,7 +686,7 @@ unsigned int CAMBEFEC::regenerateYSF3(unsigned char* bytes) const
 
 	// c3
 	g1 = 0U;
-	for (int i = 0U; i < 23U; i++)
+	for (int i = 0; i < 23; i++)
 		g1 = (g1 << 1) | (bit[i] ? 0x01U : 0x00U);
 	unsigned int c3data = CGolay24128::decode23127(g1);
 	g2 = CGolay24128::encode23127(c3data);


### PR DESCRIPTION
Removed the signedness from i to get rid of the warning:

--- %< ----

g++ -g -O3 -Wall -std=c++0x -c -o AMBEFEC.o AMBEFEC.cpp
AMBEFEC.cpp: In member function ‘unsigned int CAMBEFEC::regenerateYSF3(unsigned char*) const’:
AMBEFEC.cpp:689:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for (int i = 0U; i < 23U; i++)
                       ^
--- %< ---