### PR TITLE
callsign variable now as reference

### DIFF
--- a/DStarControl.cpp
+++ b/DStarControl.cpp
@@ -489,15 +489,13 @@ void CDStarControl::writeNetwork()
 
 		LINK_STATUS status = LS_NONE;
 		unsigned char reflector[DSTAR_LONG_CALLSIGN_LENGTH];
-		if (m_network != NULL)
-			m_network->getStatus(status, reflector);
-
-		m_display->writeDStar((char*)my1, (char*)my2, (char*)your, "N", (char*) reflector);
-
-		if (strcmp((char*) reflector, "        ") == 0) {
-			LogMessage("D-Star, received network header from %8.8s/%4.4s to %8.8s", my1, my2, your);
-		} else {
+		m_network->getStatus(status, reflector);
+		if (status == LS_LINKED_DEXTRA || status == LS_LINKED_DPLUS || status == LS_LINKED_DCS || status == LS_LINKED_CCS || status == LS_LINKED_LOOPBACK) {
+			m_display->writeDStar((char*)my1, (char*)my2, (char*)your, "N", (char*) reflector);
 			LogMessage("D-Star, received network header from %8.8s/%4.4s to %8.8s via %8.8s", my1, my2, your, reflector);
+		} else {
+			m_display->writeDStar((char*)my1, (char*)my2, (char*)your, "N", (char*) "        ");
+			LogMessage("D-Star, received network header from %8.8s/%4.4s to %8.8s", my1, my2, your);
 		}
 	} else if (type == TAG_EOT) {
 		if (m_netState != RS_NET_AUDIO)

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -590,7 +590,7 @@ void CMMDVMHost::createDisplay()
 		LogInfo("    Port: %s", port.c_str());
 		LogInfo("    Brightness: %u", brightness);
 
-		m_display = new CNextion(callsign.c_str(), dmrid, port, brightness);
+		m_display = new CNextion(callsign, dmrid, port, brightness);
 #if defined(HD44780)
 	} else if (type == "HD44780") {
 		unsigned int rows    = m_conf.getHD44780Rows();

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -23,14 +23,14 @@
 #include <cassert>
 #include <cstring>
 
-CNextion::CNextion(const char* callsign, unsigned int dmrid, const std::string& port, unsigned int brightness) :
+CNextion::CNextion(const std::string& callsign, unsigned int dmrid, const std::string& port, unsigned int brightness) :
 m_callsign(callsign),
 m_dmrid(dmrid),
 m_serial(port, SERIAL_9600),
 m_brightness(brightness),
 m_mode(MODE_IDLE)
 {
-	assert(callsign != NULL);
+	assert(callsign.c_str() != NULL);
 	assert(brightness >= 0U && brightness <= 100U);
 }
 
@@ -62,7 +62,7 @@ void CNextion::setIdle()
 	sendCommand("page MMDVM");
 
 	char command[30];
-	::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign, m_dmrid);
+	::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign.c_str(), m_dmrid);
 
 	sendCommand(command);
 	sendCommand("t1.txt=\"MMDVM IDLE\"");

--- a/Nextion.h
+++ b/Nextion.h
@@ -28,7 +28,7 @@
 class CNextion : public IDisplay
 {
 public:
-  CNextion(const char* callsign, unsigned int dmrid, const std::string& port, unsigned int brightness);
+  CNextion(const std::string& callsign, unsigned int dmrid, const std::string& port, unsigned int brightness);
   virtual ~CNextion();
 
   virtual bool open();
@@ -50,7 +50,7 @@ public:
   virtual void close();
 
 private:
-  const char*       m_callsign;
+  std::string       m_callsign;
   unsigned int      m_dmrid;
   CSerialController m_serial;
   unsigned int      m_brightness;


### PR DESCRIPTION
Adressing the issue discussed in the MMDVM Yahoo group where in some cases the callsign is not correctly shown on the idle page of Nextion (and probably others) displays.

Another issue is that MMDVMHost does not know initially if it is linked or not. I made a differentiation in the code to show the via info only if link status is known.