### PR TITLE
HD44780 PWM backlight control

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -110,6 +110,10 @@ m_tftSerialBrightness(50U),
 m_hd44780Rows(2U),
 m_hd44780Columns(16U),
 m_hd44780Pins(),
+m_hd44780PWM(),
+m_hd44780PWMPin(),
+m_hd44780PWMBright(),
+m_hd44780PWMDim(),
 m_nextionSize(),
 m_nextionPort(),
 m_nextionBrightness(50U)
@@ -340,6 +344,17 @@ bool CConf::read()
 			m_hd44780Rows = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "Columns") == 0)
 			m_hd44780Columns = (unsigned int)::atoi(value);
+
+		// WFV
+		else if (::strcmp(key, "PWM") == 0)
+			m_hd44780PWM = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "PWMPin") == 0)
+			m_hd44780PWMPin = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "PWMBright") == 0)
+			m_hd44780PWMBright = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "PWMDim") == 0)
+			m_hd44780PWMDim = (unsigned int)::atoi(value);
+
 		else if (::strcmp(key, "Pins") == 0) {
 			char* p = ::strtok(value, ",\r\n");
 			while (p != NULL) {
@@ -681,6 +696,27 @@ unsigned int CConf::getHD44780Columns() const
 std::vector<unsigned int> CConf::getHD44780Pins() const
 {
 	return m_hd44780Pins;
+}
+
+// WFV
+unsigned int CConf::getHD44780PWM() const
+{
+	return m_hd44780PWM;
+}
+
+unsigned int CConf::getHD44780PWMPin() const
+{
+	return m_hd44780PWMPin;
+}
+
+unsigned int CConf::getHD44780PWMBright() const
+{
+	return m_hd44780PWMBright;
+}
+
+unsigned int CConf::getHD44780PWMDim() const
+{
+	return m_hd44780PWMDim;
 }
 
 std::string CConf::getNextionSize() const

--- a/Conf.h
+++ b/Conf.h
@@ -118,6 +118,12 @@ public:
   unsigned int getHD44780Columns() const;
   std::vector<unsigned int> getHD44780Pins() const;
 
+  // WFV
+	unsigned int getHD44780PWM() const;
+  unsigned int getHD44780PWMPin() const;
+  unsigned int getHD44780PWMBright() const;
+  unsigned int getHD44780PWMDim() const;
+
   // The Nextion section
   std::string  getNextionSize() const;
   std::string  getNextionPort() const;
@@ -200,6 +206,12 @@ private:
   unsigned int m_hd44780Rows;
   unsigned int m_hd44780Columns;
   std::vector<unsigned int> m_hd44780Pins;
+
+	//WFV
+  unsigned int m_hd44780PWM;
+  unsigned int m_hd44780PWMPin;
+  unsigned int m_hd44780PWMBright;
+  unsigned int m_hd44780PWMDim;
 
   std::string  m_nextionSize;
   std::string  m_nextionPort;

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -20,6 +20,7 @@
 #include "Log.h"
 
 #include <wiringPi.h>
+#include <softPwm.h>
 #include <lcd.h>
 
 #include <cstdio>
@@ -28,7 +29,7 @@
 
 const char* LISTENING = "Listening                               ";
 
-CHD44780::CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins) :
+CHD44780::CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, unsigned int PWM, unsigned int PWMPin, unsigned int PWMBright, unsigned int PWMDim) :
 m_rows(rows),
 m_cols(cols),
 m_callsign(callsign),
@@ -39,6 +40,13 @@ m_d0(pins.at(2U)),
 m_d1(pins.at(3U)),
 m_d2(pins.at(4U)),
 m_d3(pins.at(5U)),
+
+// WFV
+m_PWM(PWM),
+m_PWMPin(PWMPin),
+m_PWMBright(PWMBright),
+m_PWMDim(PWMDim),
+
 m_fd(-1),
 m_dmr(false)
 {
@@ -53,6 +61,18 @@ CHD44780::~CHD44780()
 bool CHD44780::open()
 {
 	::wiringPiSetup();
+
+	// WFV
+	if (m_PWM == 1U) {
+		if (m_PWMPin != 1U) {
+			::softPwmCreate(m_PWMPin, 0, 100);
+			::softPwmWrite(m_PWMPin, m_PWMDim);
+		}
+		else {
+			::pinMode(m_PWMPin, PWM_OUTPUT);
+			::pwmWrite(m_PWMPin, m_PWMDim);
+		}
+	}
 
 #ifdef ADAFRUIT_DISPLAY
         adafruitLCDSetup();
@@ -91,6 +111,16 @@ void CHD44780::setIdle()
 {
 	::lcdClear(m_fd);
 
+	// WFV
+	if (m_PWM == 1U) {
+		if (m_PWMPin != 1U) {
+			::softPwmWrite(m_PWMPin, m_PWMDim);
+		}
+		else {
+			::pwmWrite(m_PWMPin, m_PWMDim);
+		}
+	}
+
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPrintf(m_fd, "%-6s / %u", m_callsign.c_str(), m_dmrid);
 
@@ -106,6 +136,16 @@ void CHD44780::setError(const char* text)
 
 	::lcdClear(m_fd);
 
+	// WFV
+	if (m_PWM == 1U) {
+		if (m_PWMPin != 1U) {
+			::softPwmWrite(m_PWMPin, m_PWMBright);
+		}
+		else {
+			::pwmWrite(m_PWMPin, m_PWMBright);
+		}
+	}
+
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPuts(m_fd, "MMDVM");
 
@@ -118,6 +158,16 @@ void CHD44780::setError(const char* text)
 void CHD44780::setLockout()
 {
 	::lcdClear(m_fd);
+
+	// WFV
+	if (m_PWM == 1U) {
+		if (m_PWMPin != 1U) {
+			::softPwmWrite(m_PWMPin, m_PWMBright);
+		}
+		else {
+			::pwmWrite(m_PWMPin, m_PWMBright);
+		}
+	}
 
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPuts(m_fd, "MMDVM");
@@ -137,6 +187,16 @@ void CHD44780::writeDStar(const char* my1, const char* my2, const char* your, co
 	assert(reflector != NULL);
 
 	::lcdClear(m_fd);
+
+	// WFV
+	if (m_PWM == 1U) {
+		if (m_PWMPin != 1U) {
+			::softPwmWrite(m_PWMPin, m_PWMBright);
+		}
+		else {
+			::pwmWrite(m_PWMPin, m_PWMBright);
+		}
+	}
 
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPuts(m_fd, "D-Star");
@@ -215,6 +275,16 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 
 	if (!m_dmr) {
 		::lcdClear(m_fd);
+
+		// WFV
+		if (m_PWM == 1U) {
+			if (m_PWMPin != 1U) {
+				::softPwmWrite(m_PWMPin, m_PWMBright);
+			}
+			else {
+				::pwmWrite(m_PWMPin, m_PWMBright);
+			}
+		}
 
 		if (m_rows == 2U && m_cols == 16U) {
 			if (slotNo == 1U) {
@@ -348,6 +418,16 @@ void CHD44780::writeFusion(const char* source, const char* dest)
 	assert(dest != NULL);
 
 	::lcdClear(m_fd);
+
+	// WFV
+	if (m_PWM == 1U) {
+		if (m_PWMPin != 1U) {
+			::softPwmWrite(m_PWMPin, m_PWMBright);
+		}
+		else {
+			::pwmWrite(m_PWMPin, m_PWMBright);
+		}
+	}
 
 	::lcdPosition(m_fd, 0, 0);
 	::lcdPuts(m_fd, "System Fusion");

--- a/HD44780.h
+++ b/HD44780.h
@@ -37,7 +37,7 @@
 class CHD44780 : public IDisplay
 {
 public:
-  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins);
+  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, unsigned int PWM, unsigned int PWMPin, unsigned int PWMBright, unsigned int PWMDim);
   virtual ~CHD44780();
 
   virtual bool open();
@@ -69,6 +69,13 @@ private:
 	unsigned int m_d1;
 	unsigned int m_d2;
 	unsigned int m_d3;
+
+	// WFV
+	unsigned int m_PWM;
+	unsigned int m_PWMPin;
+	unsigned int m_PWMBright;
+	unsigned int m_PWMDim;
+
 	int          m_fd;
 	bool         m_dmr;
 

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -86,6 +86,13 @@ Rows=2
 Columns=16
 # rs, strb, d0, d1, d2, d3
 # Pins=11,10,0,1,2,3
+
+# PWM brightness control
+PWM=1
+PWMPin=21
+PWMBright=100
+PWMDim=16
+
 # Adafruit i2c HD44780
 Pins=115,113,112,111,110,109
 

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -568,9 +568,15 @@ void CMMDVMHost::readParams()
 
 void CMMDVMHost::createDisplay()
 {
-	std::string type     = m_conf.getDisplay();
-	std::string callsign = m_conf.getCallsign();
-	unsigned int dmrid   = m_conf.getDMRId();
+	std::string type       = m_conf.getDisplay();
+	std::string callsign   = m_conf.getCallsign();
+	unsigned int dmrid     = m_conf.getDMRId();
+
+	// WFV
+	unsigned int PWM       = m_conf.getHD44780PWM();
+	unsigned int PWMPin    = m_conf.getHD44780PWMPin();
+	unsigned int PWMBright = m_conf.getHD44780PWMBright();
+	unsigned int PWMDim    = m_conf.getHD44780PWMDim();
 
 	LogInfo("Display Parameters");
 	LogInfo("    Type: %s", type.c_str());
@@ -604,7 +610,15 @@ void CMMDVMHost::createDisplay()
 			LogInfo("    Columns: %u", columns);
 			LogInfo("    Pins: %u,%u,%u,%u,%u,%u", pins.at(0U), pins.at(1U), pins.at(2U), pins.at(3U), pins.at(4U), pins.at(5U));
 
-			m_display = new CHD44780(rows, columns, callsign, dmrid, pins);
+			// WFV
+			if (PWM == 1U) {
+				LogInfo("PWM Brightness Control Enabled");
+				LogInfo("    PWM Pin: %u", PWMPin);
+				LogInfo("    PWM Bright: %u", PWMBright);
+				LogInfo("    PWM Dim: %u", PWMDim);
+			}
+
+			m_display = new CHD44780(rows, columns, callsign, dmrid, pins, PWM, PWMPin, PWMBright, PWMDim);
 		}
 #endif
 	} else {


### PR DESCRIPTION
**Added PWM backlight for HD44780 LCD**

It uses **hardware** PWM if you select wiringPi pin 1 - GPIO 1 - for the backlight, but as this pin is probably already in use by the LCD in MMDVMHost, you can opt for any other free GPIO pin (I opted for wiringPi pin 21 - GPIO 5) and the code does what's necessary for **software** PWM.

I've not been able to test hardware PWM (due to the way my LCD is connected - soldered!) but software PWM works fine.