### PR TITLE
Better usage of display with DVMega

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -115,6 +115,7 @@ m_hd44780PWM(false),
 m_hd44780PWMPin(),
 m_hd44780PWMBright(),
 m_hd44780PWMDim(),
+m_hd44780DVMegaDisplay(false),
 m_nextionSize("2.4"),
 m_nextionPort("/dev/ttyAMA0"),
 m_nextionBrightness(50U)
@@ -355,6 +356,8 @@ bool CConf::read()
 			m_hd44780PWMBright = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "PWMDim") == 0)
 			m_hd44780PWMDim = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "DVMegaDisplay") == 0)
+			m_hd44780DVMegaDisplay = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "Pins") == 0) {
 			char* p = ::strtok(value, ",\r\n");
 			while (p != NULL) {
@@ -721,6 +724,11 @@ unsigned int CConf::getHD44780PWMBright() const
 unsigned int CConf::getHD44780PWMDim() const
 {
 	return m_hd44780PWMDim;
+}
+
+bool CConf::getHD44780DVMegaDisplay() const
+{
+	return m_hd44780DVMegaDisplay;
 }
 
 std::string CConf::getNextionSize() const

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -357,7 +357,7 @@ bool CConf::read()
 		else if (::strcmp(key, "PWMDim") == 0)
 			m_hd44780PWMDim = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "DVMegaDisplay") == 0)
-			m_hd44780DVMegaDisplay = (unsigned int)::atoi(value);
+			m_hd44780DVMegaDisplay = ::atoi(value) == 1;
 		else if (::strcmp(key, "Pins") == 0) {
 			char* p = ::strtok(value, ",\r\n");
 			while (p != NULL) {

--- a/Conf.h
+++ b/Conf.h
@@ -122,6 +122,7 @@ public:
   unsigned int getHD44780PWMPin() const;
   unsigned int getHD44780PWMBright() const;
   unsigned int getHD44780PWMDim() const;
+  bool         getHD44780DVMegaDisplay() const;
 
   // The Nextion section
   std::string  getNextionSize() const;
@@ -210,6 +211,7 @@ private:
   unsigned int m_hd44780PWMPin;
   unsigned int m_hd44780PWMBright;
   unsigned int m_hd44780PWMDim;
+  bool         m_hd44780DVMegaDisplay;
 
   std::string  m_nextionSize;
   std::string  m_nextionPort;

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -411,7 +411,7 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 //				::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
 				::lcdPrintf(m_fd, "%-16s", buffer);
 
-				::sprintf(buffer, "To  : %s", dst.c_str());
+				::sprintf(buffer, "To  : %s%s", group ? "TG" : "", dst.c_str());
 				::lcdPosition(m_fd, 0, 1);
 //				::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
 				::lcdPrintf(m_fd, "%-16s", buffer);

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -341,16 +341,20 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 		}
 
 		if (m_rows == 2U && m_cols == 16U) {
-			if (slotNo == 1U) {
-				::lcdPosition(m_fd, 0, 1);
-				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+			if (!m_dvmegaDisplay) {
+				if (slotNo == 1U) {
+					::lcdPosition(m_fd, 0, 1);
+					::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+				} else {
+					::lcdPosition(m_fd, 0, 0);
+					::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+				}
 			} else {
 				::lcdPosition(m_fd, 0, 0);
-				if (m_dvmegaDisplay) {
-					::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
-				else
-					::lcdPuts(m_fd, "DMR");
-				}
+				::lcdPuts(m_fd, "DMR             ");
+				::lcdPosition(m_fd, 0, 1);
+//				::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
+				::lcdPrintf(m_fd, "%-16s", "Listening...");
 			}
 		} else if (m_rows == 4U && m_cols == 16U) {
 			::lcdPosition(m_fd, 0, 0);
@@ -401,11 +405,16 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 				::lcdPosition(m_fd, 0, 1);
 				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 			}
-		else {
+		} else {
+				::sprintf(buffer, "From: %s", src.c_str());
 				::lcdPosition(m_fd, 0, 0);
-				::lcdPrintf(m_fd, "From: %s", src.c_str());
-				::lcdPosition(m_fd, 0, 0);
-				::lcdPrintf(m_fd, "To  : %s%s", group ? "TG" : "", dst.c_str());
+//				::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
+				::lcdPrintf(m_fd, "%-16s", buffer);
+
+				::sprintf(buffer, "To  : %s", dst.c_str());
+				::lcdPosition(m_fd, 0, 1);
+//				::lcdPrintf(m_fd, "%.*s", m_cols, buffer);
+				::lcdPrintf(m_fd, "%-16s", buffer);
 		}
 	} else if (m_rows == 4U && m_cols == 16U) {
 #ifdef ADAFRUIT_DISPLAY
@@ -464,12 +473,20 @@ void CHD44780::clearDMR(unsigned int slotNo)
 #endif
 
 	if (m_rows == 2U && m_cols == 16U) {
-		if (slotNo == 1U) {
-			::lcdPosition(m_fd, 0, 0);
-			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+		if (!m_dvmegaDisplay) {
+			if (slotNo == 1U) {
+				::lcdPosition(m_fd, 0, 0);
+				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, LISTENING);
+			} else {
+				::lcdPosition(m_fd, 0, 1);
+				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+			}
 		} else {
+			::lcdPosition(m_fd, 0, 0);
+			::lcdPuts(m_fd, "DMR             ");
 			::lcdPosition(m_fd, 0, 1);
-			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, LISTENING);
+//			::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
+			::lcdPrintf(m_fd, "%-16s", "Listening...");
 		}
 	} else if (m_rows == 4U && m_cols == 16U) {
 		if (slotNo == 1U) {

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -354,7 +354,7 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 				::lcdPuts(m_fd, "DMR             ");
 				::lcdPosition(m_fd, 0, 1);
 //				::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
-				::lcdPrintf(m_fd, "%-16s", "Listening...");
+				::lcdPrintf(m_fd, "%-16s", "Listening");
 			}
 		} else if (m_rows == 4U && m_cols == 16U) {
 			::lcdPosition(m_fd, 0, 0);
@@ -397,11 +397,11 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 		char buffer[16U];
 		if (!m_dvmegaDisplay) {
 			if (slotNo == 1U) {
-				::sprintf(buffer, "%s >%s%s", src.c_str(), group ? "TG" : "", dst.c_str());
+				::sprintf(buffer, "%s > %s%s", src.c_str(), group ? "TG" : "", dst.c_str());
 				::lcdPosition(m_fd, 0, 0);
 				::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
 			} else {
-				::sprintf(buffer, "%s >%s%s", src.c_str(), group ? "TG" : "", dst.c_str());
+				::sprintf(buffer, "%s > %s%s", src.c_str(), group ? "TG" : "", dst.c_str());
 				::lcdPosition(m_fd, 0, 1);
 				::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 			}
@@ -423,11 +423,11 @@ void CHD44780::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 
 		char buffer[16U];
 		if (slotNo == 1U) {
-			::sprintf(buffer, "%s %s >%s%s", type, src.c_str(), group ? "TG" : "", dst.c_str());
+			::sprintf(buffer, "%s %s > %s%s", type, src.c_str(), group ? "TG" : "", dst.c_str());
 			::lcdPosition(m_fd, 0, 1);
 			::lcdPrintf(m_fd, "1 %.*s", m_cols - 2U, buffer);
 		} else {
-			::sprintf(buffer, "%s %s >%s%s", type, src.c_str(), group ? "TG" : "", dst.c_str());
+			::sprintf(buffer, "%s %s > %s%s", type, src.c_str(), group ? "TG" : "", dst.c_str());
 			::lcdPosition(m_fd, 0, 2);
 			::lcdPrintf(m_fd, "2 %.*s", m_cols - 2U, buffer);
 		}
@@ -486,7 +486,7 @@ void CHD44780::clearDMR(unsigned int slotNo)
 			::lcdPuts(m_fd, "DMR             ");
 			::lcdPosition(m_fd, 0, 1);
 //			::lcdPrintf(m_fd, "%.*s", m_cols, LISTENING);
-			::lcdPrintf(m_fd, "%-16s", "Listening...");
+			::lcdPrintf(m_fd, "%-16s", "Listening");
 		}
 	} else if (m_rows == 4U && m_cols == 16U) {
 		if (slotNo == 1U) {

--- a/HD44780.h
+++ b/HD44780.h
@@ -51,7 +51,7 @@ enum ADAFRUIT_COLOUR {
 class CHD44780 : public IDisplay
 {
 public:
-  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool DVMegaDisplay);
+  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool dvmegaDisplay);
   virtual ~CHD44780();
 
   virtual bool open();

--- a/HD44780.h
+++ b/HD44780.h
@@ -51,7 +51,7 @@ enum ADAFRUIT_COLOUR {
 class CHD44780 : public IDisplay
 {
 public:
-  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim);
+  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool DVMegaDisplay);
   virtual ~CHD44780();
 
   virtual bool open();
@@ -87,6 +87,7 @@ private:
 	unsigned int m_pwmPin;
 	unsigned int m_pwmBright;
 	unsigned int m_pwmDim;
+	bool         m_dvmegaDisplay;
 	int          m_fd;
 	bool         m_dmr;
 

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -97,6 +97,9 @@ PWMDim=16
 # Adafruit i2c HD44780
 Pins=115,113,112,111,110,109
 
+# Use redundant display real estate when connected to a DVMega
+DVMegaDisplay=0
+
 [Nextion]
 Size=2.4
 Port=/dev/ttyAMA0

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -691,6 +691,7 @@ void CMMDVMHost::createDisplay()
 		unsigned int pwmPin = m_conf.getHD44780PWMPin();
 		unsigned int pwmBright = m_conf.getHD44780PWMBright();
 		unsigned int pwmDim = m_conf.getHD44780PWMDim();
+		bool dvmegaDisplay = m_conf.getHD44780DVMegaDisplay();
 
 		if (pins.size() == 6U) {
 			LogInfo("    Rows: %u", rows);
@@ -704,7 +705,10 @@ void CMMDVMHost::createDisplay()
 				LogInfo("    PWM Dim: %u", pwmDim);
 			}
 
-			m_display = new CHD44780(rows, columns, callsign, dmrid, pins, pwm, pwmPin, pwmBright, pwmDim);
+			if (dvmegaDisplay)
+				LogInfo("Using DVMega display output on 16x2 HD44780");
+
+			m_display = new CHD44780(rows, columns, callsign, dmrid, pins, pwm, pwmPin, pwmBright, pwmDim, dvmegaDisplay);
 		}
 #endif
 	} else {

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -706,7 +706,7 @@ void CMMDVMHost::createDisplay()
 			}
 
 			if (dvmegaDisplay)
-				LogInfo("Using DVMega display output on 16x2 HD44780");
+				LogInfo("Using DVMega display output on HD44780");
 
 			m_display = new CHD44780(rows, columns, callsign, dmrid, pins, pwm, pwmPin, pwmBright, pwmDim, dvmegaDisplay);
 		}


### PR DESCRIPTION
As timeslots are irrelevant when using a DVMega, this code uses both lines of a 16x2 HD44780 to display source and destination information.  It's a starting point for (some of) the other screens ...

 **Jon** - Can you look at the way I had to use _%-16s_ rather than _%.*s, m_cols_ to get the screen to clear previous existing characters?  I'm not sure why I couldn't get it to work  the way it originally sent the LISTENING const, callsign and TG data to the lcd.  Most likely, I've done something wrong!

