### PR TITLE
Moved HD44780 RGB backlight logic control to .h file

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -107,44 +107,44 @@ void CHD44780::adafruitLCDColour(ADAFRUIT_COLOUR colour)
 {
 	switch (colour) {
 		 case AC_OFF:
-		 		::digitalWrite(AF_RED, HIGH);
-		 		::digitalWrite(AF_GREEN, HIGH);
-		 		::digitalWrite(AF_BLUE, HIGH);
+		 		::digitalWrite(AF_RED, AF_OFF);
+		 		::digitalWrite(AF_GREEN, AF_OFF);
+		 		::digitalWrite(AF_BLUE, AF_OFF);
 		 		break;
 		 case AC_WHITE:
-		 		::digitalWrite(AF_RED, LOW);
-		 		::digitalWrite(AF_GREEN, LOW);
-		 		::digitalWrite(AF_BLUE, LOW);
+		 		::digitalWrite(AF_RED, AF_ON);
+		 		::digitalWrite(AF_GREEN, AF_ON);
+		 		::digitalWrite(AF_BLUE, AF_ON);
 		 		break;
 		 case AC_RED:
-		 		::digitalWrite(AF_RED, LOW);
-		 		::digitalWrite(AF_GREEN, HIGH);
-		 		::digitalWrite(AF_BLUE, HIGH);
+		 		::digitalWrite(AF_RED, AF_ON);
+		 		::digitalWrite(AF_GREEN, AF_OFF);
+		 		::digitalWrite(AF_BLUE, AF_OFF);
 		 		break;
 		 case AC_GREEN:
-		 		::digitalWrite(AF_RED, HIGH);
-		 		::digitalWrite(AF_GREEN, LOW);
-		 		::digitalWrite(AF_BLUE, HIGH);
+		 		::digitalWrite(AF_RED, AF_OFF);
+		 		::digitalWrite(AF_GREEN, AF_ON);
+		 		::digitalWrite(AF_BLUE, AF_OFF);
 		 		break;
 		 case AC_BLUE:
-		 		::digitalWrite(AF_RED, HIGH);
-		 		::digitalWrite(AF_GREEN, HIGH);
-		 		::digitalWrite(AF_BLUE, LOW);
+		 		::digitalWrite(AF_RED, AF_OFF);
+		 		::digitalWrite(AF_GREEN, AF_OFF);
+		 		::digitalWrite(AF_BLUE, AF_ON);
 		 		break;
 		 case AC_PURPLE:
-		 		::digitalWrite(AF_RED, LOW);
-		 		::digitalWrite(AF_GREEN, HIGH);
-		 		::digitalWrite(AF_BLUE, LOW);
+		 		::digitalWrite(AF_RED, AF_ON);
+		 		::digitalWrite(AF_GREEN, AF_OFF);
+		 		::digitalWrite(AF_BLUE, AF_ON);
 		 		break;
 		 case AC_YELLOW:
-		 		::digitalWrite(AF_RED, LOW);
-		 		::digitalWrite(AF_GREEN, LOW);
-		 		::digitalWrite(AF_BLUE, HIGH);
+		 		::digitalWrite(AF_RED, AF_ON);
+		 		::digitalWrite(AF_GREEN, AF_ON);
+		 		::digitalWrite(AF_BLUE, AF_OFF);
 		 		break;
 		 case AC_ICE:
-		 		::digitalWrite(AF_RED, HIGH);
-		 		::digitalWrite(AF_GREEN, LOW);
-		 		::digitalWrite(AF_BLUE, LOW);
+		 		::digitalWrite(AF_RED, AF_OFF);
+		 		::digitalWrite(AF_GREEN, AF_ON);
+		 		::digitalWrite(AF_BLUE, AF_ON);
 		 		break;
 		 default:
 		 	break;

--- a/HD44780.h
+++ b/HD44780.h
@@ -44,7 +44,8 @@ enum ADAFRUIT_COLOUR {
 #define AF_GREEN        (AF_BASE + 7)
 #define AF_BLUE         (AF_BASE + 8)
 #define AF_RW           (AF_BASE + 14)
-#define AF_RW           (AF_BASE + 14)
+#define AF_ON		LOW
+#define AF_OFF		HIGH
 #define MCP23017        0x20
 #endif
 


### PR DESCRIPTION
Added constant AF_ON and AF_OFF in HD44780.h file to control RGB backlight in stead of hardcoding it. 

This way all changes from Adafruit to RGB1602 LCD shield can be done in HD44780.h without changing .cpp.
