### PR TITLE
Attempt to solve one cause of "No reply from modem" loop

### DIFF
--- a/DMRIPSC.cpp
+++ b/DMRIPSC.cpp
@@ -317,10 +317,21 @@ void CDMRIPSC::clock(unsigned int ms)
 				m_timeoutTimer.start();
 				m_retryTimer.start();
 			} else {
+				/*
 				LogError("Login to the master has failed, stopping IPSC");
 				m_status = DISCONNECTED;
 				m_timeoutTimer.stop();
 				m_retryTimer.stop();
+				*/
+
+				/* Once the modem death spiral has been prevented in Modem.cpp
+				   the IPSC sometimes times out and reaches here.
+				   We want it to reconnect so... */
+
+				LogError("Login to the master has failed, retrying ...");
+				close();
+				open();
+				return;
 			}
 		} else if (::memcmp(m_buffer, "RPTACK",  6U) == 0) {
 			switch (m_status) {

--- a/Modem.cpp
+++ b/Modem.cpp
@@ -156,6 +156,10 @@ bool CModem::open()
 	if (!ret) {
 		m_serial.close();
 		return false;
+	} else {
+		/* Stopping the inactivity timer here when a firmware version has been
+		   successfuly read prevents the death spiral of "no reply from modem..." */
+		m_inactivityTimer.stop();
 	}
 
 	ret = setFrequency();


### PR DESCRIPTION
"err 101" (network unreachable - effectively cant get to the master because we've lost the network)

This needs trapping and handling properly to smooth the way it currently tries to send from the socket as quickly as it can (effectively every millisecond) until the network is restored,  then does the same for "Opening IPSC" every millisecond or less until the login either times out (in which case I've edited the code to tell it to retry!) or logs into the master successfully.

This error also causes the "no reply from modem loop, however this is now trapped in all cases if the firmware is read successfully by stopping the inactivity timer, allowing the software to continue reading the modem.

It works for this particular error, but others may need to test!