### PR TITLE
Add [-v|--version] flag to command line

### DIFF
--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -71,8 +71,8 @@ const char* HEADER4 = "Copyright(C) 2015, 2016 by Jonathan Naylor, G4KLX and oth
 
 int main(int argc, char** argv)
 {
-  const char* iniFile = DEFAULT_INI_FILE;
-  if (argc > 1) {
+	const char* iniFile = DEFAULT_INI_FILE;
+	if (argc > 1) {
 		for (int currentArg = 1; currentArg < argc; ++currentArg) {
 			std::string arg = argv[currentArg];
 			if ((arg == "-v") || (arg == "--version")) {

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv)
 		for (int currentArg = 1; currentArg < argc; ++currentArg) {
 			std::string arg = argv[currentArg];
 			if ((arg == "-v") || (arg == "--version")) {
-				::fprintf(stdout, "MMDVMHost %s\n", VERSION);
+				::fprintf(stdout, "MMDVMHost version %s\n", VERSION);
 				return 0;
 			} else if (arg.substr(0,1) == "-") {
 				::fprintf(stderr, "Usage: MMDVMHost [-v|--version] [filename]\n");

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -72,8 +72,17 @@ const char* HEADER4 = "Copyright(C) 2015, 2016 by Jonathan Naylor, G4KLX and oth
 int main(int argc, char** argv)
 {
   const char* iniFile = DEFAULT_INI_FILE;
-  if (argc > 1)
-	iniFile = argv[1];
+  if (argc > 1) {
+		for (int currentArg = 1; currentArg < argc; ++currentArg) {
+			std::string arg = argv[currentArg];
+			if ((arg == "-v") || (arg == "--version")) {
+				::fprintf(stdout, "MMDVMHost %s\n", VERSION);
+				return 0;
+			} else {
+				iniFile = argv[currentArg];
+			}
+		}
+	}
 
 #if !defined(_WIN32) && !defined(_WIN64)
   ::signal(SIGTERM, sigHandler);
@@ -128,13 +137,13 @@ int CMMDVMHost::run()
 {
 	bool ret = m_conf.read();
 	if (!ret) {
-		::fprintf(stderr, "MMDVMHost-%s: cannot read the .ini file\n", VERSION);
+		::fprintf(stderr, "MMDVMHost: cannot read the .ini file\n");
 		return 1;
 	}
 
 	ret = ::LogInitialise(m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel());
 	if (!ret) {
-		::fprintf(stderr, "MMDVMHost-%s: unable to open the log file\n", VERSION);
+		::fprintf(stderr, "MMDVMHost: unable to open the log file\n");
 		return 1;
 	}
 

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -78,6 +78,9 @@ int main(int argc, char** argv)
 			if ((arg == "-v") || (arg == "--version")) {
 				::fprintf(stdout, "MMDVMHost %s\n", VERSION);
 				return 0;
+			} else if (arg.substr(0,1) == "-") {
+				::fprintf(stderr, "Usage: MMDVMHost [-v|--version] [filename]\n");
+				return 1;
 			} else {
 				iniFile = argv[currentArg];
 			}

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -128,13 +128,13 @@ int CMMDVMHost::run()
 {
 	bool ret = m_conf.read();
 	if (!ret) {
-		::fprintf(stderr, "MMDVMHost: cannot read the .ini file\n");
+		::fprintf(stderr, "MMDVMHost-%s: cannot read the .ini file\n", VERSION);
 		return 1;
 	}
 
 	ret = ::LogInitialise(m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel());
 	if (!ret) {
-		::fprintf(stderr, "MMDVMHost: unable to open the log file\n");
+		::fprintf(stderr, "MMDVMHost-%s: unable to open the log file\n", VERSION);
 		return 1;
 	}
 
@@ -306,7 +306,7 @@ int CMMDVMHost::run()
 
 	setMode(MODE_IDLE);
 
-	LogMessage("MMDVMHost is running");
+	LogMessage("MMDVMHost-%s is running", VERSION);
 
 	while (!m_killed) {
 		bool lockout = m_modem->hasLockout();
@@ -554,7 +554,7 @@ int CMMDVMHost::run()
 		}
 	}
 
-	LogMessage("MMDVMHost is exiting on receipt of SIGHUP1");
+	LogMessage("MMDVMHost-%s is exiting on receipt of SIGHUP1", VERSION);
 
 	setMode(MODE_IDLE);
 


### PR DESCRIPTION
They now output the string MMDVMHost-yyymmdd

a) for completeness 

and;

b) to quickly output the version number by calling the host executable with no arguments so Kim can easily grab it for his dashboard.

I did think about a -v|--version argument, but this was much simpler for the purpose.