### PR TITLE
Correcting minor mistake in FICH MR bit manipulation.

### DIFF
--- a/YSFFICH.cpp
+++ b/YSFFICH.cpp
@@ -193,7 +193,7 @@ void CYSFFICH::setFI(unsigned char fi)
 void CYSFFICH::setMR(unsigned char mr)
 {
 	m_fich[2U] &= 0xC7U;
-	m_fich[2U] |= mr;
+	m_fich[2U] |= (mr << 3) & 0x38U;
 }
 
 void CYSFFICH::setVoIP(bool on)


### PR DESCRIPTION
This one is fairly trivial. Fix in CYSFFICH::setMR():

After nulling out the MR bits of the YSF FICH, the new bit value is to be ORed in. For this to work, it needs to be left-shifted to the correct position within the byte. This is done correctly in CYSFFICH::setFI() but was forgotten in setMR(). setVoIP() does not require any shifting since the VoIP field is at bit-position 0.

This fixes the Fusion parrot which was erratic in DN mode, sometimes even switching an AMS receiver into VW mode. This was most likely due to the DT field being overwritten. I'm not sure if it fixes the actual 'warbling' problem that I'm trying to address but it's a start.