### PR TITLE
Typos causing confusion in ACL config

### DIFF
--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -56,10 +56,10 @@ SelfOnly=0
 LookupFile=DMRIds.dat
 TXHang=4
 #Blacklist=
-#DstIDBlackListSlot1=
-#DstIDBlackListSlot2=
-#DstIDWhiteListSlot1=
-#DstIDWhiteListSlot2=
+#DstIdBlackListSlot1=
+#DstIdBlackListSlot2=
+#DstIdWhiteListSlot1=
+#DstIdWhiteListSlot2=
 
 
 [System Fusion]

--- a/README.DMR_ACL
+++ b/README.DMR_ACL
@@ -10,7 +10,7 @@ So, for example:
 
 DstIdBlackListSlot1=91 - block the TG91 net.
 
-DstIdWhiteSlot1=9.5057,9990 - allows TG9, APRS SMS Gateway and Echo. 
+DstIdWhiteListSlot1=9.5057,9990 - allows TG9, APRS SMS Gateway and Echo. 
 
 If the whitelist is null and commented out, it is disabled. 
 


### PR DESCRIPTION
Fixed a couple of typos in the readme and MMDVM.ini 