### PR TITLE
Use a dot as date separator optionally

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -912,6 +912,11 @@ bool CConf::getHD44780UTC() const
 	return m_hd44780UTC;
 }
 
+std::string CConf::getHD44780DateFormat() const
+{
+	return m_hd44780DateFormat;
+}
+
 std::string CConf::getNextionPort() const
 {
 	return m_nextionPort;

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -139,6 +139,7 @@ m_nextionPort("/dev/ttyAMA0"),
 m_nextionBrightness(50U),
 m_nextionDisplayClock(false),
 m_nextionUTC(false),
+m_nextionDateFormat("English"),
 m_oledType(3),
 m_oledBrightness(0),
 m_oledInvert(0)
@@ -461,6 +462,8 @@ bool CConf::read()
 			m_nextionDisplayClock = ::atoi(value) == 1;
 		else if (::strcmp(key, "UTC") == 0)
 			m_nextionUTC = ::atoi(value) == 1;
+		else if (::strcmp(key, "DateFormat") == 0)
+			m_nextionDateFormat = value;
 	} else if (section == SECTION_OLED) {
 		if (::strcmp(key, "Type") == 0)
 			m_oledType = (unsigned char)::atoi(value);
@@ -924,6 +927,11 @@ bool CConf::getNextionDisplayClock() const
 bool CConf::getNextionUTC() const
 {
 	return m_nextionUTC;
+}
+
+std::string CConf::getNextionDateFormat() const
+{
+	return m_nextionDateFormat;
 }
 
 unsigned char CConf::getOLEDType() const

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -135,6 +135,7 @@ m_hd44780PWMBright(),
 m_hd44780PWMDim(),
 m_hd44780DisplayClock(false),
 m_hd44780UTC(false),
+m_hd44780DateFormat("English"),
 m_nextionPort("/dev/ttyAMA0"),
 m_nextionBrightness(50U),
 m_nextionDisplayClock(false),
@@ -445,6 +446,8 @@ bool CConf::read()
 			m_hd44780DisplayClock = ::atoi(value) == 1;
 		else if (::strcmp(key, "UTC") == 0)
 			m_hd44780UTC = ::atoi(value) == 1;
+		else if (::strcmp(key, "DateFormat") == 0)
+			m_hd44780DateFormat = value;
 		else if (::strcmp(key, "Pins") == 0) {
 			char* p = ::strtok(value, ",\r\n");
 			while (p != NULL) {

--- a/Conf.h
+++ b/Conf.h
@@ -142,6 +142,7 @@ public:
   unsigned int getHD44780PWMDim() const;
   bool         getHD44780DisplayClock() const;
   bool         getHD44780UTC() const;
+  std::string  getHD44780DateFormat() const;
 
   // The Nextion section
   std::string  getNextionPort() const;
@@ -256,6 +257,7 @@ private:
   unsigned int m_hd44780PWMDim;
   bool         m_hd44780DisplayClock;
   bool         m_hd44780UTC;
+  std::string  m_hd44780DateFormat;
 
   std::string  m_nextionPort;
   unsigned int m_nextionBrightness;

--- a/Conf.h
+++ b/Conf.h
@@ -148,6 +148,7 @@ public:
   unsigned int getNextionBrightness() const;
   bool         getNextionDisplayClock() const;
   bool         getNextionUTC() const;
+  std::string  getNextionDateFormat() const;
 
   // The OLED section
   unsigned char  getOLEDType() const;
@@ -260,6 +261,7 @@ private:
   unsigned int m_nextionBrightness;
   bool         m_nextionDisplayClock;
   bool         m_nextionUTC;
+  std::string  m_nextionDateFormat;
 
   unsigned char m_oledType;
   unsigned char m_oledBrightness;

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -36,7 +36,7 @@ char        m_buffer2[128U];
 char        m_buffer3[128U];
 char        m_buffer4[128U];
 
-CHD44780::CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool displayClock, bool utc, bool duplex) :
+CHD44780::CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool displayClock, bool utc, bool duplex, const std::string& dateformat) :
 CDisplay(),
 m_rows(rows),
 m_cols(cols),
@@ -56,6 +56,7 @@ m_displayClock(displayClock),
 m_utc(utc),
 m_duplex(duplex),
 //m_duplex(true),                      // uncomment to force duplex display for testing!
+m_dateformat(dateformat),
 m_fd(-1),
 m_dmr(false),
 m_clockDisplayTimer(1000U, 0U, 75U),   // Update the clock display every 75ms
@@ -734,7 +735,11 @@ void CHD44780::clockInt(unsigned int ms)
 
 			if (m_cols != 16U && m_rows != 2U) {
 				::lcdPosition(m_fd, (m_cols - 8) / 2, m_rows == 2 ? 0 : 1);
-				::lcdPrintf(m_fd, "%02d/%02d/%2d", Day, Month, Year%100);
+				if (strcmp(m_dateformat.c_str(), "English") == 0) {
+					::lcdPrintf(m_fd, "%02d/%02d/%2d", Day, Month, Year%100);
+				} else if (strcmp(m_dateformat.c_str(), "German") == 0) {
+					::lcdPrintf(m_fd, "%02d.%02d.%2d", Day, Month, Year%100);
+				}
 			}
 			m_clockDisplayTimer.start();
 	}

--- a/HD44780.h
+++ b/HD44780.h
@@ -53,7 +53,7 @@ enum ADAFRUIT_COLOUR {
 class CHD44780 : public CDisplay
 {
 public:
-  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool displayClock, bool utc, bool duplex);
+  CHD44780(unsigned int rows, unsigned int cols, const std::string& callsign, unsigned int dmrid, const std::vector<unsigned int>& pins, bool pwm, unsigned int pwmPin, unsigned int pwmBright, unsigned int pwmDim, bool displayClock, bool utc, bool duplex, const std::string& dateformat);
   virtual ~CHD44780();
 
   virtual bool open();
@@ -94,6 +94,7 @@ private:
 	bool         m_displayClock;
 	bool         m_utc;
 	bool         m_duplex;
+	std::string  m_dateformat;
 	int          m_fd;
 	bool         m_dmr;
 	CTimer       m_clockDisplayTimer;

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -124,6 +124,7 @@ Port=/dev/ttyAMA0
 Brightness=50
 DisplayClock=1
 UTC=0
+DateFormat=English
 
 [OLED]
 Type=3

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -844,15 +844,16 @@ void CMMDVMHost::createDisplay()
 		m_display = new CNextion(m_callsign, dmrid, port, brightness, displayClock, utc, dateformat);
 #if defined(HD44780)
 	} else if (type == "HD44780") {
-		unsigned int rows    = m_conf.getHD44780Rows();
-		unsigned int columns = m_conf.getHD44780Columns();
+		unsigned int rows              = m_conf.getHD44780Rows();
+		unsigned int columns           = m_conf.getHD44780Columns();
 		std::vector<unsigned int> pins = m_conf.getHD44780Pins();
-		bool pwm = m_conf.getHD44780PWM();
-		unsigned int pwmPin = m_conf.getHD44780PWMPin();
-		unsigned int pwmBright = m_conf.getHD44780PWMBright();
-		unsigned int pwmDim = m_conf.getHD44780PWMDim();
-		bool displayClock = m_conf.getHD44780DisplayClock();
-		bool utc = m_conf.getHD44780UTC();
+		bool pwm                       = m_conf.getHD44780PWM();
+		unsigned int pwmPin            = m_conf.getHD44780PWMPin();
+		unsigned int pwmBright         = m_conf.getHD44780PWMBright();
+		unsigned int pwmDim            = m_conf.getHD44780PWMDim();
+		bool displayClock              = m_conf.getHD44780DisplayClock();
+		bool utc                       = m_conf.getHD44780UTC();
+		std::string dateformat         = m_conf.getHD44780DateFormat();
 
 		if (pins.size() == 6U) {
 			LogInfo("    Rows: %u", rows);
@@ -870,7 +871,7 @@ void CMMDVMHost::createDisplay()
 			if (displayClock)
 				LogInfo("    Display UTC: %s", utc ? "yes" : "no");
 
-			m_display = new CHD44780(rows, columns, m_callsign, dmrid, pins, pwm, pwmPin, pwmBright, pwmDim, displayClock, utc, m_duplex);
+			m_display = new CHD44780(rows, columns, m_callsign, dmrid, pins, pwm, pwmPin, pwmBright, pwmDim, displayClock, utc, m_duplex, dateformat);
 		}
 #endif
 #if defined(OLED)

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -833,6 +833,7 @@ void CMMDVMHost::createDisplay()
 		unsigned int brightness = m_conf.getNextionBrightness();
 		bool displayClock       = m_conf.getNextionDisplayClock();
 		bool utc                = m_conf.getNextionUTC();
+		std::string dateformat  = m_conf.getNextionDateFormat();
 
 		LogInfo("    Port: %s", port.c_str());
 		LogInfo("    Brightness: %u", brightness);
@@ -840,7 +841,7 @@ void CMMDVMHost::createDisplay()
 		if (displayClock)
 			LogInfo("    Display UTC: %s", utc ? "yes" : "no");
 
-		m_display = new CNextion(m_callsign, dmrid, port, brightness, displayClock, utc);
+		m_display = new CNextion(m_callsign, dmrid, port, brightness, displayClock, utc, dateformat);
 #if defined(HD44780)
 	} else if (type == "HD44780") {
 		unsigned int rows    = m_conf.getHD44780Rows();

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -244,10 +244,8 @@ void CNextion::clockInt(unsigned int ms)
 		char text[50U];
 		if (strcmp(m_dateformat.c_str(), "English") == 0) {
 			::sprintf(text, "t2.txt=\"%02d:%02d:%02d %02d/%02d/%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
-			printf(text, "t2.txt=\"%02d:%02d:%02d %02d/%02d/%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
 		} else if (strcmp(m_dateformat.c_str(), "German") == 0) {
 			::sprintf(text, "t2.txt=\"%02d:%02d:%02d %02d.%02d.%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
-			printf(text, "t2.txt=\"%02d:%02d:%02d %02d.%02d.%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
 		}
 		sendCommand(text);
 

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -24,7 +24,7 @@
 #include <cstring>
 #include <ctime>
 
-CNextion::CNextion(const std::string& callsign, unsigned int dmrid, const std::string& port, unsigned int brightness, bool displayClock, bool utc) :
+CNextion::CNextion(const std::string& callsign, unsigned int dmrid, const std::string& port, unsigned int brightness, bool displayClock, bool utc, const std::string& dateformat) :
 CDisplay(),
 m_callsign(callsign),
 m_dmrid(dmrid),
@@ -33,6 +33,7 @@ m_brightness(brightness),
 m_mode(MODE_IDLE),
 m_displayClock(displayClock),
 m_utc(utc),
+m_dateformat(dateformat),
 m_clockDisplayTimer(1000U, 0U, 400U)
 {
 	assert(brightness >= 0U && brightness <= 100U);
@@ -241,7 +242,13 @@ void CNextion::clockInt(unsigned int ms)
 		int Sec = Time->tm_sec;
 
 		char text[50U];
-		::sprintf(text, "t2.txt=\"%02d:%02d:%02d %02d/%02d/%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
+		if (strcmp(m_dateformat.c_str(), "English") == 0) {
+			::sprintf(text, "t2.txt=\"%02d:%02d:%02d %02d/%02d/%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
+			printf(text, "t2.txt=\"%02d:%02d:%02d %02d/%02d/%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
+		} else if (strcmp(m_dateformat.c_str(), "German") == 0) {
+			::sprintf(text, "t2.txt=\"%02d:%02d:%02d %02d.%02d.%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
+			printf(text, "t2.txt=\"%02d:%02d:%02d %02d.%02d.%2d\"", Hour, Min, Sec, Day, Month, Year % 100);
+		}
 		sendCommand(text);
 
 		m_clockDisplayTimer.start(); // restart the clock display timer

--- a/Nextion.h
+++ b/Nextion.h
@@ -29,7 +29,7 @@
 class CNextion : public CDisplay
 {
 public:
-  CNextion(const std::string& callsign, unsigned int dmrid, const std::string& port, unsigned int brightness, bool displayClock, bool utc);
+  CNextion(const std::string& callsign, unsigned int dmrid, const std::string& port, unsigned int brightness, bool displayClock, bool utc, const std::string& dateformat);
   virtual ~CNextion();
 
   virtual bool open();
@@ -60,6 +60,7 @@ private:
   unsigned char     m_mode;
   bool              m_displayClock;
   bool              m_utc;
+  std::string       m_dateformat;
   CTimer            m_clockDisplayTimer;
 
   void sendCommand(const char* command);


### PR DESCRIPTION
I added a simple config option to change the field seaparator for displaying the date on Nextion and HD44780 displays. If desired I would implement another option to change it to MDY format.