### PR TITLE
Add support for HD44780 when connected via PCF8574 I2C

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -206,12 +206,16 @@ bool CHD44780::open()
   adafruitLCDSetup();
 #endif
 
+#ifdef PCF8574_DISPLAY
+	pcf8574LCDSetup();
+#endif
+
 	m_fd = ::lcdInit(m_rows, m_cols, 4, m_rb, m_strb, m_d0, m_d1, m_d2, m_d3, 0, 0, 0, 0);
 	if (m_fd == -1) {
 		LogError("Unable to open the HD44780");
 		return false;
 	}
-
+	
 	::lcdDisplay(m_fd, 1);
 	::lcdCursor(m_fd, 0);
 	::lcdCursorBlink(m_fd, 0);
@@ -293,6 +297,36 @@ void CHD44780::adafruitLCDColour(ADAFRUIT_COLOUR colour)
 		 default:
 		 	break;
 	}
+}
+#endif
+
+#ifdef PCF8574_DISPLAY
+void CHD44780::pcf8574LCDSetup()
+{
+	// Initalize PFC8574
+	::pcf8574Setup(AF_BASE, PCF8574);
+
+	// Initialise LCD
+	m_fd = ::lcdInit(m_rows, m_cols, 4, AF_RS, AF_E, AF_D1, AF_D2, AF_D3, AF_D4, 0, 0, 0, 0);
+	if (m_fd == -1) {
+		LogError("Unable to open the HD44780 via I2C");
+		return false;
+	}
+
+	m_rb   = AF_RS;
+	m_strb = AF_E;
+	m_d0   = AF_D1;
+	m_d1   = AF_D2;
+	m_d2   = AF_D3;
+	m_d3   = AF_D4;
+
+	// Turn on backlight
+	::pinMode (AF_BL, OUTPUT);
+	::digitalWrite (AF_BL, 1);
+
+	// Set LCD to write mode.
+	::pinMode (AF_RW, OUTPUT);
+	::digitalWrite (AF_RW, 0);
 }
 #endif
 

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -249,6 +249,13 @@ void CHD44780::adafruitLCDSetup()
     // Control signals
     ::pinMode(AF_RW, OUTPUT);
     ::digitalWrite(AF_RW, LOW);
+
+		m_rb   = AF_RS;
+		m_strb = AF_E;
+		m_d0   = AF_D0;
+		m_d1   = AF_D1;
+		m_d2   = AF_D2;
+		m_d3   = AF_D3;
 }
 
 void CHD44780::adafruitLCDColour(ADAFRUIT_COLOUR colour)
@@ -316,17 +323,17 @@ void CHD44780::pcf8574LCDSetup()
 
 	m_rb   = AF_RS;
 	m_strb = AF_E;
-	m_d0   = AF_D1;
-	m_d1   = AF_D2;
-	m_d2   = AF_D3;
-	m_d3   = AF_D4;
+	m_d0   = AF_D0;
+	m_d1   = AF_D1;
+	m_d2   = AF_D2;
+	m_d3   = AF_D3;
 }
 #endif
 
 void CHD44780::setIdleInt()
 {
-	m_dmrScrollTimer1.stop();                // Stop the scroll timer on slot 1
-	m_dmrScrollTimer2.stop();                // Stop the scroll timer on slot 2
+	m_dmrScrollTimer1.stop();             // Stop the scroll timer on slot 1
+	m_dmrScrollTimer2.stop();             // Stop the scroll timer on slot 2
 	m_clockDisplayTimer.start();          // Start the clock display in IDLE only
 	::lcdClear(m_fd);
 	
@@ -369,8 +376,8 @@ void CHD44780::setErrorInt(const char* text)
 #endif
 
 	m_clockDisplayTimer.stop();           // Stop the clock display
-	m_dmrScrollTimer1.stop();                // Stop the scroll timer on slot 1
-	m_dmrScrollTimer2.stop();                // Stop the scroll timer on slot 2
+	m_dmrScrollTimer1.stop();             // Stop the scroll timer on slot 1
+	m_dmrScrollTimer2.stop();             // Stop the scroll timer on slot 2
 	::lcdClear(m_fd);
 
 	if (m_pwm) {

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -306,20 +306,6 @@ void CHD44780::pcf8574LCDSetup()
 	// Initalize PFC8574
 	::pcf8574Setup(AF_BASE, PCF8574);
 
-	// Initialise LCD
-	m_fd = ::lcdInit(m_rows, m_cols, 4, AF_RS, AF_E, AF_D1, AF_D2, AF_D3, AF_D4, 0, 0, 0, 0);
-	if (m_fd == -1) {
-		LogError("Unable to open the HD44780 via I2C");
-		return false;
-	}
-
-	m_rb   = AF_RS;
-	m_strb = AF_E;
-	m_d0   = AF_D1;
-	m_d1   = AF_D2;
-	m_d2   = AF_D3;
-	m_d3   = AF_D4;
-
 	// Turn on backlight
 	::pinMode (AF_BL, OUTPUT);
 	::digitalWrite (AF_BL, 1);
@@ -327,6 +313,13 @@ void CHD44780::pcf8574LCDSetup()
 	// Set LCD to write mode.
 	::pinMode (AF_RW, OUTPUT);
 	::digitalWrite (AF_RW, 0);
+
+	m_rb   = AF_RS;
+	m_strb = AF_E;
+	m_d0   = AF_D1;
+	m_d1   = AF_D2;
+	m_d2   = AF_D3;
+	m_d3   = AF_D4;
 }
 #endif
 

--- a/HD44780.h
+++ b/HD44780.h
@@ -62,7 +62,7 @@ enum ADAFRUIT_COLOUR {
 #define AF_D2     (AF_BASE + 5)
 #define AF_D3     (AF_BASE + 6)
 #define AF_D4     (AF_BASE + 7)
-#define PCF8547		0x27
+#define PCF8574		0x27
 #endif
 
 class CHD44780 : public CDisplay

--- a/HD44780.h
+++ b/HD44780.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <mcp23017.h>
+#include <pcf8574.h>
 
 enum ADAFRUIT_COLOUR {
 	AC_OFF,
@@ -40,14 +41,28 @@ enum ADAFRUIT_COLOUR {
 
 // Defines for the Adafruit Pi LCD interface board
 #ifdef ADAFRUIT_DISPLAY
-#define AF_BASE         100
-#define AF_RED          (AF_BASE + 6)
-#define AF_GREEN        (AF_BASE + 7)
-#define AF_BLUE         (AF_BASE + 8)
-#define AF_RW           (AF_BASE + 14)
-#define AF_ON		LOW
+#define AF_BASE   100
+#define AF_RED    (AF_BASE + 6)
+#define AF_GREEN  (AF_BASE + 7)
+#define AF_BLUE   (AF_BASE + 8)
+#define AF_RW     (AF_BASE + 14)
+#define AF_ON		  LOW
 #define AF_OFF		HIGH
-#define MCP23017        0x20
+#define MCP23017  0x20
+#endif
+
+// Define for HD44780 connected via a PCF8574 GPIO extender
+#ifdef PCF8574_DISPLAY
+#define AF_BASE   100
+#define AF_RS     (AF_BASE + 0)
+#define AF_RW     (AF_BASE + 1)
+#define AF_E      (AF_BASE + 2)
+#define AF_BL     (AF_BASE + 3)
+#define AF_D1     (AF_BASE + 4)
+#define AF_D2     (AF_BASE + 5)
+#define AF_D3     (AF_BASE + 6)
+#define AF_D4     (AF_BASE + 7)
+#define PCF8547		0x27
 #endif
 
 class CHD44780 : public CDisplay
@@ -104,6 +119,10 @@ private:
 #ifdef ADAFRUIT_DISPLAY
   void adafruitLCDSetup();
   void adafruitLCDColour(ADAFRUIT_COLOUR colour);
+#endif
+
+#ifdef PCF8574_DISPLAY
+  void pcf8574LCDSetup();
 #endif
 };
 

--- a/HD44780.h
+++ b/HD44780.h
@@ -42,26 +42,47 @@ enum ADAFRUIT_COLOUR {
 // Defines for the Adafruit Pi LCD interface board
 #ifdef ADAFRUIT_DISPLAY
 #define AF_BASE   100
-#define AF_RED    (AF_BASE + 6)
-#define AF_GREEN  (AF_BASE + 7)
-#define AF_BLUE   (AF_BASE + 8)
+
+/*   Not yet used defines (for possible future use)
+ *
+ *   #define AF_SELECT (AF_BASE +  0)
+ *   #define AF_RIGHT  (AF_BASE +  1)
+ *   #define AF_DOWN   (AF_BASE +  2)
+ *   #define AF_UP     (AF_BASE +  3)
+ *   #define AF_LEFT   (AF_BASE +  4)
+ */
+
+#define AF_RED    (AF_BASE +  6)
+#define AF_GREEN  (AF_BASE +  7)
+#define AF_BLUE   (AF_BASE +  8)
+
+#define AF_D3     (AF_BASE +  9)
+#define AF_D2     (AF_BASE + 10)
+#define AF_D1     (AF_BASE + 11)
+#define AF_D0     (AF_BASE + 12)
+#define AF_E      (AF_BASE + 13)
 #define AF_RW     (AF_BASE + 14)
-#define AF_ON		  LOW
-#define AF_OFF		HIGH
+#define AF_RS     (AF_BASE + 15)
+
+#define AF_ON     LOW
+#define AF_OFF    HIGH
+
 #define MCP23017  0x20
 #endif
 
 // Define for HD44780 connected via a PCF8574 GPIO extender
 #ifdef PCF8574_DISPLAY
 #define AF_BASE   100
-#define AF_RS     (AF_BASE + 0)
-#define AF_RW     (AF_BASE + 1)
-#define AF_E      (AF_BASE + 2)
-#define AF_BL     (AF_BASE + 3)
-#define AF_D1     (AF_BASE + 4)
-#define AF_D2     (AF_BASE + 5)
-#define AF_D3     (AF_BASE + 6)
-#define AF_D4     (AF_BASE + 7)
+
+#define AF_RS     (AF_BASE +  0)
+#define AF_RW     (AF_BASE +  1)
+#define AF_E      (AF_BASE +  2)
+#define AF_BL     (AF_BASE +  3)
+#define AF_D0     (AF_BASE +  4)
+#define AF_D1     (AF_BASE +  5)
+#define AF_D2     (AF_BASE +  6)
+#define AF_D3     (AF_BASE +  7)
+
 #define PCF8574		0x27
 #endif
 

--- a/HD44780.md
+++ b/HD44780.md
@@ -6,4 +6,4 @@ to implement functions for larger screens.
 
 Here's a list of things I would like to accomplish in the near future ...
 
-- Scroll long source and destination IDs on small screens.
+- Nothing planned at this time!  Any suggestions?

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -110,8 +110,6 @@ Columns=16
 # rs, strb, d0, d1, d2, d3
 # For basic HD44780 displays
 Pins=11,10,0,1,2,3
-# For Adafruit i2c HD44780
-# Pins=115,113,112,111,110,109
 
 # PWM backlight
 PWM=0

--- a/Makefile.Pi.PCF8574
+++ b/Makefile.Pi.PCF8574
@@ -1,0 +1,24 @@
++# This makefile is for use with the Raspberry Pi when using an HD44780 compatible display. The wiringpi library is needed.
++# Support for the HD44780 connected via a PCF8574 8-bit GPIO expander IC
++CC      = gcc
++CXX     = g++
++CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -DHD44780 -DPCF8574_DISPLAY -I/usr/local/include
++LIBS    = -lwiringPi -lwiringPiDev -lpthread
++LDFLAGS = -g -L/usr/local/lib
++
++OBJECTS = \
++		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
++		DMRShortLC.o DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o \
++		Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o YSFControl.o \
++		YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
++
++all:		MMDVMHost
++
++MMDVMHost:	$(OBJECTS)
++		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
++
++%.o: %.cpp
++		$(CXX) $(CFLAGS) -c -o $@ $<
++
++clean:
++		$(RM) MMDVMHost *.o *.d *.bak *~

--- a/Makefile.Pi.PCF8574
+++ b/Makefile.Pi.PCF8574
@@ -1,24 +1,24 @@
-+# This makefile is for use with the Raspberry Pi when using an HD44780 compatible display. The wiringpi library is needed.
-+# Support for the HD44780 connected via a PCF8574 8-bit GPIO expander IC
-+CC      = gcc
-+CXX     = g++
-+CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -DHD44780 -DPCF8574_DISPLAY -I/usr/local/include
-+LIBS    = -lwiringPi -lwiringPiDev -lpthread
-+LDFLAGS = -g -L/usr/local/lib
-+
-+OBJECTS = \
-+		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
-+		DMRShortLC.o DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o \
-+		Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o YSFControl.o \
-+		YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
-+
-+all:		MMDVMHost
-+
-+MMDVMHost:	$(OBJECTS)
-+		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
-+
-+%.o: %.cpp
-+		$(CXX) $(CFLAGS) -c -o $@ $<
-+
-+clean:
-+		$(RM) MMDVMHost *.o *.d *.bak *~
+# This makefile is for use with the Raspberry Pi when using an HD44780 compatible display. The wiringpi library is needed.
+# Support for the HD44780 connected via a PCF8574 8-bit GPIO expander IC
+CC      = gcc
+CXX     = g++
+CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -DHD44780 -DPCF8574_DISPLAY -I/usr/local/include
+LIBS    = -lwiringPi -lwiringPiDev -lpthread
+LDFLAGS = -g -L/usr/local/lib
+
+OBJECTS = \
+		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
+		DMRShortLC.o DMRSlot.o DMRSlotType.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o \
+		Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o YSFControl.o \
+		YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
+
+all:		MMDVMHost
+
+MMDVMHost:	$(OBJECTS)
+		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
+
+%.o: %.cpp
+		$(CXX) $(CFLAGS) -c -o $@ $<
+
+clean:
+		$(RM) MMDVMHost *.o *.d *.bak *~

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ It supports D-Star, DMR, and System Fusion.
 It builds on 32-bit and 64-bit Linux as well as on Windows using VS2015 on x86 and x64. It can optionally control various Displays. Currently these are:
 
 - HD44780 (sizes 2x16, 2x40, 4x16, 4x20)
+	- Support for HD44780 via 4 bit GPIO connection (user selectable pins)
+	- Adafruit 16x2 LCD+Keypad Kits (I2C)
+	- Connection via PCF8574 GPIO Extender (I2C)
 - Nextion TFTs (sizes 2.4", 3.2" and 3.5")
-- Adafruit 16x2 LCD+Keypad Kits
 - TFT displays sold by Hobbytronics in UK
 - OLED 128x64 (SSD1306)
 


### PR DESCRIPTION
HD44780 with PCF8574 I2C chip - http://www.ebay.com/itm/IIC-I2C-TWI-SP-I-Serial-Interface1602-16X2-Character-LCD-Module-Display-Blue-/310565065847?hash=item484f1ed477:g:mPQAAOSwofxUhQre

Hardcode "pins" for Adafruit display as these should never change.  Same for the PCF8574 chip.

What may need to go into MMDVM.ini at some point is the I2C device ID which is currently (and always has been for the Adafruit display) hardcoded.