### PR TITLE
Fix DMR unable to log into master due to locale issues

### DIFF
--- a/DMRIPSC.cpp
+++ b/DMRIPSC.cpp
@@ -466,6 +466,7 @@ bool CDMRIPSC::writeConfig()
 	::memcpy(buffer + 0U, "RPTC", 4U);
 	::memcpy(buffer + 4U, m_id, 4U);
 
+	setlocale(LC_ALL,"C");
 	::sprintf(buffer + 8U, "%-8.8s%09u%09u%02u%02u%08f%09f%03d%-20.20s%-19.19s%c%-124.124s%-40.40s%-40.40s", m_callsign.c_str(),
 		m_rxFrequency, m_txFrequency, m_power, m_colorCode, m_latitude, m_longitude, m_height, m_location.c_str(),
 		m_description.c_str(), slots, m_url.c_str(), m_version, software);

--- a/DMRIPSC.cpp
+++ b/DMRIPSC.cpp
@@ -466,7 +466,7 @@ bool CDMRIPSC::writeConfig()
 	::memcpy(buffer + 0U, "RPTC", 4U);
 	::memcpy(buffer + 4U, m_id, 4U);
 
-	setlocale(LC_ALL,"C");
+//	setlocale(LC_ALL,"C");
 	::sprintf(buffer + 8U, "%-8.8s%09u%09u%02u%02u%08f%09f%03d%-20.20s%-19.19s%c%-124.124s%-40.40s%-40.40s", m_callsign.c_str(),
 		m_rxFrequency, m_txFrequency, m_power, m_colorCode, m_latitude, m_longitude, m_height, m_location.c_str(),
 		m_description.c_str(), slots, m_url.c_str(), m_version, software);

--- a/DMRIPSC.cpp
+++ b/DMRIPSC.cpp
@@ -466,7 +466,6 @@ bool CDMRIPSC::writeConfig()
 	::memcpy(buffer + 0U, "RPTC", 4U);
 	::memcpy(buffer + 4U, m_id, 4U);
 
-//	setlocale(LC_ALL,"C");
 	::sprintf(buffer + 8U, "%-8.8s%09u%09u%02u%02u%08f%09f%03d%-20.20s%-19.19s%c%-124.124s%-40.40s%-40.40s", m_callsign.c_str(),
 		m_rxFrequency, m_txFrequency, m_power, m_colorCode, m_latitude, m_longitude, m_height, m_location.c_str(),
 		m_description.c_str(), slots, m_url.c_str(), m_version, software);

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -752,7 +752,7 @@ void CHD44780::clockInt(unsigned int ms)
 				Time = localtime(&currentTime);
 			}
 			
-			setlocale(LC_ALL,"");
+			setlocale(LC_TIME,"");
 			strftime(m_buffer1, 128, "%X", Time);  // Time
 			strftime(m_buffer2, 128, "%x", Time);  // Date
 

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -246,7 +246,7 @@ void CNextion::clockInt(unsigned int ms)
 		else
 			Time = ::localtime(&currentTime);
 
-		setlocale(LC_ALL,"");
+		setlocale(LC_TIME,"");
 		char text[50U];
 		strftime(text, 50, "t2.txt=\"%x %X\"", Time);
 		sendCommand(text);


### PR DESCRIPTION
When system locale used commas as decimal points, writeConfig() was sending an invalid config string to the master.