### PR TITLE
Add DMRAccessControl to other Makefiles

### DIFF
--- a/Makefile.Pi.Adafruit
+++ b/Makefile.Pi.Adafruit
@@ -8,7 +8,7 @@ LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \
 		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
-		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o \
+		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o \
 		MMDVMHost.o Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o \
 		YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 

--- a/Makefile.Pi.HD44780
+++ b/Makefile.Pi.HD44780
@@ -8,7 +8,7 @@ LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \
 		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
-		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o \
+		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o \
 		MMDVMHost.o Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o \
 		YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 

--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -8,7 +8,7 @@ LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \
 		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
-		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o OLED.o Log.o \
+		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o OLED.o Log.o \
 		MMDVMHost.o Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o \
 		YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 

--- a/Makefile.Pi.PCF8574
+++ b/Makefile.Pi.PCF8574
@@ -8,7 +8,7 @@ LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \
 		AMBEFEC.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRIPSC.o DMRLookup.o DMRLC.o \
-		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o \
+		DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o Golay24128.o Hamming.o HD44780.o Log.o \
 		MMDVMHost.o Modem.o Nextion.o NullDisplay.o QR1676.o RS129.o SerialController.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o Utils.o \
 		YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 


### PR DESCRIPTION
I guess Simon forgot the other Makefiles (e.g. HD44780 etc.) in 66415e00. The DMRAccessControl.o was missing.