### PR TITLE
Correct typo in HD44780.cpp (see Yahoo Group)

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -240,7 +240,7 @@ bool CHD44780::open()
 void CHD44780::adafruitLCDSetup()
 {
     // The other control pins are initialised with lcdInit()
-    ::mcp23017Setup(AF_BASE, m_i2caddress);
+    ::mcp23017Setup(AF_BASE, m_i2cAddress);
 
     // Backlight LEDs    
     ::pinMode(AF_RED,   OUTPUT);


### PR DESCRIPTION
From the Yahoo Group:

> On line 243 of HD44780.cpp there is a typo.
> 
> is: m_i2caddress
> 
> Should be:m_i2cAddress
> 
> 
> 
> 73, Steve N4IRS