### PR TITLE
Added missing quotes in test cmd.

### DIFF
--- a/linux/init/mmdvmhost
+++ b/linux/init/mmdvmhost
@@ -37,7 +37,7 @@ set -e
 case "$1" in
         start)
             # Wait for an IP address
-            until [ $ipVar != " " ]; do
+            until [ "$ipVar" != " " ]; do
                 sleep 10
                 ipVar=`hostname -I`
             done


### PR DESCRIPTION
Found some missing quotes in test cmd when init script is executed at system boot.