### PR TITLE
TalkGroup Rewrite 

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -93,6 +93,8 @@ m_dmrBeacons(false),
 m_dmrId(0U),
 m_dmrColorCode(2U),
 m_dmrSelfOnly(false),
+m_TGRewriteSlot1(false),
+m_TGRewriteSlot2(false),
 m_dmrPrefixes(),
 m_dmrBlackList(),
 m_dmrDstIdBlacklistSlot1RF(),
@@ -330,6 +332,10 @@ bool CConf::read()
 			m_dmrColorCode = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "SelfOnly") == 0)
 			m_dmrSelfOnly = ::atoi(value) == 1;
+		else if (::strcmp(key, "TGRewriteSlot1") == 0)
+			m_TGRewriteSlot1 = ::atoi(value) == 1;
+		else if (::strcmp(key, "TGRewriteSlot2") == 0)
+			m_TGRewriteSlot2 = ::atoi(value) == 1;
 		else if (::strcmp(key, "Prefixes") == 0) {
 			char* p = ::strtok(value, ",\r\n");
 			while (p != NULL) {
@@ -746,6 +752,16 @@ unsigned int CConf::getDMRColorCode() const
 bool CConf::getDMRSelfOnly() const
 {
 	return m_dmrSelfOnly;
+}
+
+bool CConf::getDMRTGRewriteSlot1() const
+{
+	return m_TGRewriteSlot1;
+}
+
+bool CConf::getDMRTGRewriteSlot2() const
+{
+	return m_TGRewriteSlot2;
 }
 
 std::vector<unsigned int> CConf::getDMRPrefixes() const

--- a/Conf.h
+++ b/Conf.h
@@ -88,6 +88,8 @@ public:
   unsigned int getDMRId() const;
   unsigned int getDMRColorCode() const;
   bool         getDMRSelfOnly() const;
+  bool	       getDMRTGRewriteSlot1() const;
+  bool	       getDMRTGRewriteSlot2() const;
   std::vector<unsigned int> getDMRPrefixes() const;
   std::vector<unsigned int> getDMRBlackList() const;
   std::vector<unsigned int> getDMRDstIdBlacklistSlot1RF() const;
@@ -213,6 +215,8 @@ private:
   unsigned int m_dmrId;
   unsigned int m_dmrColorCode;
   bool         m_dmrSelfOnly;
+  bool	       m_TGRewriteSlot1;
+  bool	       m_TGRewriteSlot2;
   std::vector<unsigned int> m_dmrPrefixes;
   std::vector<unsigned int> m_dmrBlackList;
   std::vector<unsigned int> m_dmrDstIdBlacklistSlot1RF;

--- a/DMRAccessControl.cpp
+++ b/DMRAccessControl.cpp
@@ -197,17 +197,18 @@ unsigned int DMRAccessControl::DstIdRewrite (unsigned int id, bool network)
 	// record current time
 	m_time = std::time(nullptr);
 	// if the ID is a talkgroup, log and rewrite to TG9 
-	if (id < 4000 && id != 0) {
+	if (id < 4000 && id > 0) {
 	  LogMessage("Rewrite DST ID (TG) of of inbound network traffic from %u to 9", id);
 	  return 9;
 	} else {
 	    return 0;
 	}
   } else {
-	// if less than 30 seconds has passed since we last saw traffic 
-	if (m_dstRewriteID == id && (m_time + 30) > currenttime && m_time) {
+	// if less than 30 seconds has passed since we last saw traffic from network 
+	if (m_dstRewriteID == id && (m_time + 30) > currenttime) {
 	      LogMessage("Inbound DST ID (TG) rewrite seen in last 30 seconds");
 	      LogMessage("Rewrite DST ID (TG) of outbound network traffic from 9 to %u", id);
+	      m_time = std::time(nullptr);
 	      return(id);
 	} else {
 	    return(0);

--- a/DMRAccessControl.cpp
+++ b/DMRAccessControl.cpp
@@ -217,8 +217,8 @@ unsigned int DMRAccessControl::DstIdRewrite (unsigned int did, unsigned int sid,
 	    return 0;
 	}
   } else {
-	if (did == 9 && (m_time + m_callHang) > currenttime) {
-	      LogMessage("DMR Slot %u, Rewrite DST ID (TG) of outbound network traffic from %u to %u (return traffic during CallHang)",slot,sid,m_dstRewriteID);
+	if (did == 9 && m_dstRewriteID != 9 && (m_time + m_callHang) > currenttime) {
+	      LogMessage("DMR Slot %u, Rewrite DST ID (TG) of outbound network traffic from %u to %u (return traffic during CallHang)",slot,did,m_dstRewriteID);
 	      return(m_dstRewriteID);
 	} else {
 	    return(0);

--- a/DMRAccessControl.cpp
+++ b/DMRAccessControl.cpp
@@ -216,16 +216,15 @@ unsigned int DMRAccessControl::DstIdRewrite (unsigned int did, unsigned int sid,
 	} else {
 	    return 0;
 	}
-  } else {
-	if (did == 9 && m_dstRewriteID != 9 && (m_time + m_callHang) > currenttime) {
+  } else if (did == 9 && m_dstRewriteID != 9 && m_dstRewriteID != 0 && (m_time + m_callHang) > currenttime) {
 	      LogMessage("DMR Slot %u, Rewrite DST ID (TG) of outbound network traffic from %u to %u (return traffic during CallHang)",slot,did,m_dstRewriteID);
 	      return(m_dstRewriteID);
-	} else {
-	    return(0);
-	}
-  }
-
+  }  else if (did < 4000 && did > 0 && did !=9) {
+      m_dstRewriteID = did;
+  } 
+  return 0;
 }
+
 
 void DMRAccessControl::setOverEndTime() 
 {

--- a/DMRAccessControl.cpp
+++ b/DMRAccessControl.cpp
@@ -45,7 +45,11 @@ std::time_t DMRAccessControl::m_time;
 
 unsigned int DMRAccessControl::m_callHang;
 
-void DMRAccessControl::init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id,unsigned int callHang)
+bool DMRAccessControl::m_TGRewriteSlot1;
+bool DMRAccessControl::m_TGRewriteSlot2;
+
+
+void DMRAccessControl::init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id,unsigned int callHang,bool TGRewriteSlot1, bool TGRewriteSlot2)
 {
 	m_dstBlackListSlot1RF  = DstIdBlacklistSlot1RF;
 	m_dstWhiteListSlot1RF  = DstIdWhitelistSlot1RF;
@@ -56,6 +60,8 @@ void DMRAccessControl::init(const std::vector<unsigned int>& DstIdBlacklistSlot1
 	m_dstBlackListSlot2NET = DstIdBlacklistSlot2NET;
 	m_dstWhiteListSlot2NET = DstIdWhitelistSlot2NET;
 	m_callHang = callHang;
+	m_TGRewriteSlot1 = TGRewriteSlot1;
+	m_TGRewriteSlot2 = TGRewriteSlot2;
 }
  
 bool DMRAccessControl::DstIdBlacklist(unsigned int did, unsigned int slot, bool network)
@@ -192,6 +198,13 @@ bool DMRAccessControl::validateAccess (unsigned int src_id, unsigned int dst_id,
 
 unsigned int DMRAccessControl::DstIdRewrite (unsigned int did, unsigned int sid, unsigned int slot, bool network) 
 {
+  
+  if (slot == 1 && m_TGRewriteSlot1 == false)
+    return 0;
+  
+  if (slot == 2 && m_TGRewriteSlot2 == false)
+    return 0;
+   
   std::time_t currenttime = std::time(nullptr);
   
   if (network) {
@@ -204,8 +217,8 @@ unsigned int DMRAccessControl::DstIdRewrite (unsigned int did, unsigned int sid,
 	    return 0;
 	}
   } else {
-	if (m_SrcID == sid && (m_time + m_callHang) > currenttime) {
-	      LogMessage("DMR Slot %u, Rewrite DST ID (TG) of outbound network traffic from 9 to %u (return traffic during CallHang)",slot,m_dstRewriteID);
+	if (did == 9 && (m_time + m_callHang) > currenttime) {
+	      LogMessage("DMR Slot %u, Rewrite DST ID (TG) of outbound network traffic from %u to %u (return traffic during CallHang)",slot,sid,m_dstRewriteID);
 	      return(m_dstRewriteID);
 	} else {
 	    return(0);

--- a/DMRAccessControl.h
+++ b/DMRAccessControl.h
@@ -16,12 +16,15 @@
 #define	DMRAccessControl_H
 
 #include <vector>
+#include <ctime>
 
 class DMRAccessControl {
 public:
 	static bool validateAccess (unsigned int src_id, unsigned int dst_id, unsigned int slot, bool network);
 
 	static void init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id);
+	
+	static unsigned int DstIdRewrite(unsigned int id, bool network);
 
 private:
 	static std::vector<unsigned int> m_dstBlackListSlot1RF;
@@ -45,6 +48,12 @@ private:
 	static bool DstIdWhitelist(unsigned int did,unsigned int slot,bool gt4k, bool network);
 
 	static bool validateSrcId(unsigned int id);
+	
+	static std::time_t m_time;
+	
+	static unsigned int m_dstRewriteID;
+	
+
 };
 
 #endif

--- a/DMRAccessControl.h
+++ b/DMRAccessControl.h
@@ -22,7 +22,7 @@ class DMRAccessControl {
 public:
 	static bool validateAccess (unsigned int src_id, unsigned int dst_id, unsigned int slot, bool network);
 
-	static void init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id,unsigned int callHang);
+	static void init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id,unsigned int callHang, bool TGRewrteSlot1, bool TGRewrteSlot2);
 	
 	static unsigned int DstIdRewrite(unsigned int id, unsigned int sid,unsigned int slot, bool network);
 	static void setOverEndTime();
@@ -56,6 +56,10 @@ private:
 	
 	static unsigned int m_dstRewriteID;
 	static unsigned int m_SrcID;
+	
+	static bool m_TGRewriteSlot1;
+	static bool m_TGRewriteSlot2;
+	
 	
 
 };

--- a/DMRAccessControl.h
+++ b/DMRAccessControl.h
@@ -22,9 +22,10 @@ class DMRAccessControl {
 public:
 	static bool validateAccess (unsigned int src_id, unsigned int dst_id, unsigned int slot, bool network);
 
-	static void init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id);
+	static void init(const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, const std::vector<unsigned int>& SrcIdBlacklist, bool selfOnly, const std::vector<unsigned int>& prefixes,unsigned int id,unsigned int callHang);
 	
-	static unsigned int DstIdRewrite(unsigned int id, bool network);
+	static unsigned int DstIdRewrite(unsigned int id, unsigned int sid,unsigned int slot, bool network);
+	static void setOverEndTime();
 
 private:
 	static std::vector<unsigned int> m_dstBlackListSlot1RF;
@@ -40,6 +41,8 @@ private:
 	static std::vector<unsigned int> m_SrcIdBlacklist;
 
 	static std::vector<unsigned int> m_prefixes;
+	
+	static unsigned int m_callHang;
 
 	static bool m_selfOnly;
 	static unsigned int m_id;
@@ -52,6 +55,7 @@ private:
 	static std::time_t m_time;
 	
 	static unsigned int m_dstRewriteID;
+	static unsigned int m_SrcID;
 	
 
 };

--- a/DMRControl.cpp
+++ b/DMRControl.cpp
@@ -20,7 +20,7 @@
 #include <cassert>
 #include <algorithm>
 
-CDMRControl::CDMRControl(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& blackList, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, unsigned int timeout, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, const std::string& lookupFile, int rssiMultiplier, int rssiOffset, unsigned int jitter) :
+CDMRControl::CDMRControl(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& blackList, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF, const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, unsigned int timeout, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, const std::string& lookupFile, int rssiMultiplier, int rssiOffset, unsigned int jitter, bool TGRewriteSlot1, bool TGRewriteSlot2) :
 m_id(id),
 m_colorCode(colorCode),
 m_selfOnly(selfOnly),
@@ -38,7 +38,7 @@ m_lookup(NULL)
 	m_lookup = new CDMRLookup(lookupFile);
 	m_lookup->read();
 
-	CDMRSlot::init(id, colorCode, callHang, selfOnly, prefixes, blackList, DstIdBlacklistSlot1RF, DstIdWhitelistSlot1RF, DstIdBlacklistSlot2RF, DstIdWhitelistSlot2RF, DstIdBlacklistSlot1NET, DstIdWhitelistSlot1NET, DstIdBlacklistSlot2NET, DstIdWhitelistSlot2NET, modem, network, display, duplex, m_lookup, rssiMultiplier, rssiOffset, jitter);
+	CDMRSlot::init(id, colorCode, callHang, selfOnly, prefixes, blackList, DstIdBlacklistSlot1RF, DstIdWhitelistSlot1RF, DstIdBlacklistSlot2RF, DstIdWhitelistSlot2RF, DstIdBlacklistSlot1NET, DstIdWhitelistSlot1NET, DstIdBlacklistSlot2NET, DstIdWhitelistSlot2NET, modem, network, display, duplex, m_lookup, rssiMultiplier, rssiOffset, jitter, TGRewriteSlot1, TGRewriteSlot2);
 }
 
 CDMRControl::~CDMRControl()

--- a/DMRControl.h
+++ b/DMRControl.h
@@ -30,7 +30,7 @@
 
 class CDMRControl {
 public:
-	CDMRControl(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& blackList, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF,const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, unsigned int timeout, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, const std::string& lookupFile, int rssiMultiplier, int rssiOffset, unsigned int jitter);
+	CDMRControl(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& blackList, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF,const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, unsigned int timeout, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, const std::string& lookupFile, int rssiMultiplier, int rssiOffset, unsigned int jitter, bool TGRewriteSlot1, bool TGRewriteSlot2);
 	~CDMRControl();
 
 	bool processWakeup(const unsigned char* data);

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -262,6 +262,7 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			LogMessage("DMR Slot %u, received RF end of voice transmission, %.1f seconds, BER: %.1f%%", m_slotNo, float(m_rfFrames) / 16.667F, float(m_rfErrs * 100U) / float(m_rfBits));
 
 			writeEndRF();
+			DMRAccessControl::setOverEndTime();
 		} else if (dataType == DT_DATA_HEADER) {
 			if (m_rfState == RS_RF_DATA)
 				return;

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -1361,7 +1361,7 @@ void CDMRSlot::writeQueueNet(const unsigned char *data)
 		m_queue.addData(data, len);
 }
 
-void CDMRSlot::init(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& SrcIdBlacklist, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF,  const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, CDMRLookup* lookup, int rssiMultiplier, int rssiOffset, unsigned int jitter)
+void CDMRSlot::init(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& SrcIdBlacklist, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF,  const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, CDMRLookup* lookup, int rssiMultiplier, int rssiOffset, unsigned int jitter, bool TGRewriteSlot1, bool TGRewriteSlot2)
 {
 	assert(id != 0U);
 	assert(modem != NULL);
@@ -1396,7 +1396,7 @@ void CDMRSlot::init(unsigned int id, unsigned int colorCode, unsigned int callHa
 	slotType.getData(m_idle + 2U);
 	
 	//Load black and white lists to DMRAccessControl
-	DMRAccessControl::init(DstIdBlacklistSlot1RF, DstIdWhitelistSlot1RF, DstIdBlacklistSlot2RF, DstIdWhitelistSlot2RF, DstIdBlacklistSlot1NET, DstIdWhitelistSlot1NET, DstIdBlacklistSlot2NET, DstIdWhitelistSlot2NET, SrcIdBlacklist, m_selfOnly, m_prefixes, m_id,callHang);
+	DMRAccessControl::init(DstIdBlacklistSlot1RF, DstIdWhitelistSlot1RF, DstIdBlacklistSlot2RF, DstIdWhitelistSlot2RF, DstIdBlacklistSlot1NET, DstIdWhitelistSlot1NET, DstIdBlacklistSlot2NET, DstIdWhitelistSlot2NET, SrcIdBlacklist, m_selfOnly, m_prefixes, m_id,callHang, TGRewriteSlot1, TGRewriteSlot2);
 }
 
 

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -160,7 +160,7 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			}
 			
 			// Test dst rewrite
-			unsigned int rw_id = DMRAccessControl::DstIdRewrite(id, false);
+			unsigned int rw_id = DMRAccessControl::DstIdRewrite(did, false);
 			if (rw_id) {
 			LogMessage("Rewrite ID: %u", rw_id);
 			lc->setDstId(rw_id);
@@ -493,7 +493,7 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 				    return;
 				}
 				// Test dst rewrite
-				unsigned int rw_id = DMRAccessControl::DstIdRewrite(id, false);
+				unsigned int rw_id = DMRAccessControl::DstIdRewrite(did, false);
 				if (rw_id) {
 				LogMessage("Rewrite ID: %u", rw_id);
 				lc->setDstId(rw_id);

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -157,7 +157,14 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (!DMRAccessControl::validateAccess(id, did, m_slotNo, false)) {
 			    delete lc;
 			    return;
-			}			
+			}
+			
+			// Test dst rewrite
+			unsigned int rw_id = DMRAccessControl::DstIdRewrite(id, false);
+			if (rw_id) {
+			LogMessage("Rewrite ID: %u", rw_id);
+			lc->setDstId(rw_id);
+			}
 			
 			m_rfLC = lc;
 
@@ -271,6 +278,7 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (!DMRAccessControl::validateAccess(srcId, dstId, m_slotNo, false))
 			    return;
 
+
 			m_rfFrames = dataHeader.getBlocks();
 
 			m_rfDataHeader = dataHeader;
@@ -325,7 +333,7 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			unsigned int dstId = csbk.getDstId();
 			if (!DMRAccessControl::validateAccess(srcId, dstId, m_slotNo, false))
 			    return;
-
+			
 			// Regenerate the CSBK data
 			csbk.get(data + 2U);
 
@@ -483,6 +491,12 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 				if (!DMRAccessControl::validateAccess(id,did,m_slotNo,false)) {
 				    delete lc;
 				    return;
+				}
+				// Test dst rewrite
+				unsigned int rw_id = DMRAccessControl::DstIdRewrite(id, false);
+				if (rw_id) {
+				LogMessage("Rewrite ID: %u", rw_id);
+				lc->setDstId(rw_id);
 				}
 
 				m_rfLC = lc;

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -157,7 +157,7 @@ void CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (!DMRAccessControl::validateAccess(id, did, m_slotNo, false)) {
 			    delete lc;
 			    return;
-			}
+			}			
 			
 			m_rfLC = lc;
 
@@ -762,6 +762,13 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 		unsigned int id = m_netLC->getSrcId();
 		if (!DMRAccessControl::validateAccess(id, did, m_slotNo, true))
 		    return;
+		
+		// Test dst rewrite
+		unsigned int rw_id = DMRAccessControl::DstIdRewrite(id, true);
+		if (rw_id) {
+		    LogMessage("Rewrite ID: %u", rw_id);
+		    m_netLC->setDstId(rw_id);
+		}
 
 		// Store the LC for the embedded LC
 		m_netEmbeddedLC.setData(*m_netLC);
@@ -825,6 +832,13 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 		unsigned int id = m_netLC->getSrcId();
 		if (!DMRAccessControl::validateAccess(id, did, m_slotNo, true))
 		    return;
+		
+		// Test dst rewrite
+		unsigned int rw_id = DMRAccessControl::DstIdRewrite(id,true);
+		if (rw_id) {
+		    LogMessage("Rewrite ID: %u", rw_id);
+		    m_netLC->setDstId(rw_id);
+		}
 
 		// Regenerate the Slot Type
 		CDMRSlotType slotType;

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -774,11 +774,11 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 
 		unsigned int did = m_netLC->getDstId();
 		unsigned int id = m_netLC->getSrcId();
-		if (!DMRAccessControl::validateAccess(id, did, m_slotNo, true))
+		if (!DMRAccessControl::validateAccess(did, did, m_slotNo, true))
 		    return;
 		
 		// Test dst rewrite
-		unsigned int rw_id = DMRAccessControl::DstIdRewrite(id, true);
+		unsigned int rw_id = DMRAccessControl::DstIdRewrite(did, true);
 		if (rw_id) {
 		    LogMessage("Rewrite ID: %u", rw_id);
 		    m_netLC->setDstId(rw_id);

--- a/DMRSlot.h
+++ b/DMRSlot.h
@@ -50,7 +50,7 @@ public:
 
 	void clock();
 
-	static void init(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& SrcIdBlackList, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF,  const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, CDMRLookup* lookup, int rssiMultiplier, int rssiOffset, unsigned int jitter);
+	static void init(unsigned int id, unsigned int colorCode, unsigned int callHang, bool selfOnly, const std::vector<unsigned int>& prefixes, const std::vector<unsigned int>& SrcIdBlackList, const std::vector<unsigned int>& DstIdBlacklistSlot1RF, const std::vector<unsigned int>& DstIdWhitelistSlot1RF, const std::vector<unsigned int>& DstIdBlacklistSlot2RF, const std::vector<unsigned int>& DstIdWhitelistSlot2RF,  const std::vector<unsigned int>& DstIdBlacklistSlot1NET, const std::vector<unsigned int>& DstIdWhitelistSlot1NET, const std::vector<unsigned int>& DstIdBlacklistSlot2NET, const std::vector<unsigned int>& DstIdWhitelistSlot2NET, CModem* modem, CDMRIPSC* network, CDisplay* display, bool duplex, CDMRLookup* lookup, int rssiMultiplier, int rssiOffset, unsigned int jitter, bool TGRewriteSlot1, bool TGRewriteSlot2);
 
 private:
 	unsigned int               m_slotNo;

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -296,6 +296,8 @@ int CMMDVMHost::run()
 		unsigned int id        = m_conf.getDMRId();
 		unsigned int colorCode = m_conf.getDMRColorCode();
 		bool selfOnly          = m_conf.getDMRSelfOnly();
+		bool TGRewriteSlot1    = m_conf.getDMRTGRewriteSlot1();
+		bool TGRewriteSlot2    = m_conf.getDMRTGRewriteSlot2();
 		std::vector<unsigned int> prefixes = m_conf.getDMRPrefixes();
 		std::vector<unsigned int> blackList = m_conf.getDMRBlackList();
 		std::vector<unsigned int> dstIDBlackListSlot1RF = m_conf.getDMRDstIdBlacklistSlot1RF();
@@ -354,8 +356,15 @@ int CMMDVMHost::run()
 			LogInfo("    RSSI Multiplier: %d", rssiMultiplier);
 			LogInfo("    RSSI Offset: %d", rssiOffset);
 		}
+		
+		if (TGRewriteSlot1)
+		  LogInfo("    TG Rewrite Slot 1 enabled");
+		
+		if (TGRewriteSlot2)
+		  LogInfo("    TG Rewrite Slot 2 enabled");
+		
 
-		dmr = new CDMRControl(id, colorCode, callHang, selfOnly, prefixes, blackList,dstIDBlackListSlot1RF,dstIDWhiteListSlot1RF, dstIDBlackListSlot2RF, dstIDWhiteListSlot2RF, dstIDBlackListSlot1NET,dstIDWhiteListSlot1NET, dstIDBlackListSlot2NET, dstIDWhiteListSlot2NET, m_timeout, m_modem, m_dmrNetwork, m_display, m_duplex, lookupFile, rssiMultiplier, rssiOffset, jitter);
+		dmr = new CDMRControl(id, colorCode, callHang, selfOnly, prefixes, blackList,dstIDBlackListSlot1RF,dstIDWhiteListSlot1RF, dstIDBlackListSlot2RF, dstIDWhiteListSlot2RF, dstIDBlackListSlot1NET,dstIDWhiteListSlot1NET, dstIDBlackListSlot2NET, dstIDWhiteListSlot2NET, m_timeout, m_modem, m_dmrNetwork, m_display, m_duplex, lookupFile, rssiMultiplier, rssiOffset, jitter, TGRewriteSlot1, TGRewriteSlot2);
 
 		m_dmrTXTimer.setTimeout(txHang);
 	}

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -1,0 +1,31 @@
+Talk-Group Rewrite was conceived as a way of making talk-groups behave more 
+like the reflector system and of attempting to solve the problem of "slot 
+contention",where the user may be locked out of a slot by traffic on a 
+talk-group they know nothing about, without knowing why. This is frustrating to 
+users, both those new to DMR and seasoned DMR users. 
+
+TG Rewrite, when enabled for a slot, rewrites the DST ID of incoming talkgroup 
+traffic to TG9, alowing audio to be heard by any user monitoring TG9 on that 
+slot. If the user then replies on TG9, as long as they key-up during the 
+CallHang period, the DST ID (TG) is again rewritten on the outbound traffic, 
+which transparently maps back to the originating talkgroup. 
+
+To use a User Activated talk-group, briefly key-up on that talk-group to 
+activate it, then switch back to TG9 and talk as normal. If the CallHang period 
+expires, you may need to activate the talk-group again by keying up on that 
+talkgroup briefly, as before. 
+
+It is useful to set the CallHang parameter to a generous amount. I am currently 
+using seven seconds. 
+
+Two configuration options control the TG Rewrite feature:
+
+TGRewriteSlot1=
+TGRewriteSlot2=
+
+ACL's are applied before the rewrite, so still apply to rewritten traffic on source talk-group. 
+
+73
+
+Simon (G7RZU)
+

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -18,10 +18,10 @@ talkgroup briefly, as before.
 It is useful to set the CallHang parameter to a generous amount. I am currently 
 using seven seconds. 
 
-Two configuration options control the TG Rewrite feature:
+Two boolean configuration options control the TG Rewrite feature:
 
-TGRewriteSlot1=
-TGRewriteSlot2=
+TGRewriteSlot1=[0|1]
+TGRewriteSlot2=[0|1]
 
 ACL's are applied before the rewrite, so still apply to rewritten traffic on source talk-group. 
 

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -18,12 +18,19 @@ talkgroup briefly, as before.
 It is useful to set the CallHang parameter to a generous amount. I am currently 
 using seven seconds. 
 
+If you don't like having to switch back to TG9. You can programme a channel for 
+your target TG but add an RX list which also includes TG 9 to your channel 
+definition. Just switch to that chanel and QSO as normal. You'll still hear the 
+return traffic, but so will everyone else monitoring TG 9, they can even join 
+in, even if they don't have the target TG programmed in their codeplug.
+
 Two boolean configuration options control the TG Rewrite feature:
 
 TGRewriteSlot1=[0|1]
 TGRewriteSlot2=[0|1]
 
-ACL's are applied before the rewrite, so still apply to rewritten traffic on source talk-group. 
+ACL's are applied before the rewrite, so still apply to rewritten traffic on 
+original (non-rewritten) talk-group. 
 
 73
 

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -8,12 +8,20 @@ TG Rewrite, when enabled for a slot, rewrites the DST ID of incoming talkgroup
 traffic to TG9, alowing audio to be heard by any user monitoring TG9 on that 
 slot. If the user then replies on TG9, as long as they key-up during the 
 CallHang period, the DST ID (TG) is again rewritten on the outbound traffic, 
-which transparently maps back to the originating talkgroup. 
+which transparently maps back to the originating talkgroup. Rewrite is also 
+enabled if an outbound call is made to a talkgroup and then TG9 is activated 
+during the callhang period. 
 
 To use a User Activated talk-group, briefly key-up on that talk-group to 
 activate it, then switch back to TG9 and talk as normal. If the CallHang period 
 expires, you may need to activate the talk-group again by keying up on that 
 talkgroup briefly, as before. 
+
+Note, proper ettiquette dictates that the user confirms the repeater is free 
+before activiating this feature. It is best to ensure the slot is keyed from 
+"cold" when activating a talkgroup for rewrite. Although not strictly neccesary, 
+it may be advantageous to also disconnect the repeater from the reflector system 
+first, if using slot 2.
 
 It is useful to set the CallHang parameter to a generous amount. I am currently 
 using seven seconds. 

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -18,11 +18,6 @@ talkgroup briefly, as before.
 It is useful to set the CallHang parameter to a generous amount. I am currently 
 using seven seconds. 
 
-If you don't like having to switch back to TG9. You can programme a channel for 
-your target TG but add an RX list which also includes TG 9 to your channel 
-definition. Just switch to that chanel and QSO as normal. You'll still hear the 
-return traffic, but so will everyone else monitoring TG 9, they can even join 
-in, even if they don't have the target TG programmed in their codeplug.
 
 Two boolean configuration options control the TG Rewrite feature:
 

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -24,6 +24,9 @@ before activiating this feature. It is best to ensure the slot is keyed from
 neccesary, it may be advantageous to also disconnect the repeater from the 
 reflector system first, if using slot 2.
 
+Talk-group rewrite was originally intended to work with User-Activated talk 
+groups, although it will function with permanent talk-groups too. 
+
 It is useful to set the CallHang parameter to a generous amount. I am currently 
 using seven seconds. 
 

--- a/README.TGRewrite
+++ b/README.TGRewrite
@@ -10,18 +10,19 @@ slot. If the user then replies on TG9, as long as they key-up during the
 CallHang period, the DST ID (TG) is again rewritten on the outbound traffic, 
 which transparently maps back to the originating talkgroup. Rewrite is also 
 enabled if an outbound call is made to a talkgroup and then TG9 is activated 
-during the callhang period. 
+during the CallHang period. 
 
 To use a User Activated talk-group, briefly key-up on that talk-group to 
 activate it, then switch back to TG9 and talk as normal. If the CallHang period 
 expires, you may need to activate the talk-group again by keying up on that 
-talkgroup briefly, as before. 
+talkgroup briefly, as before. Alternatively, you can wait for inbound audio to 
+re-activate the rewrite, then respond during the CallHang period. 
 
 Note, proper ettiquette dictates that the user confirms the repeater is free 
 before activiating this feature. It is best to ensure the slot is keyed from 
-"cold" when activating a talkgroup for rewrite. Although not strictly neccesary, 
-it may be advantageous to also disconnect the repeater from the reflector system 
-first, if using slot 2.
+"cold" when activating a talkgroup for rewrite. Although not strictly 
+neccesary, it may be advantageous to also disconnect the repeater from the 
+reflector system first, if using slot 2.
 
 It is useful to set the CallHang parameter to a generous amount. I am currently 
 using seven seconds. 


### PR DESCRIPTION
Hi,

Below is the README.TGRewrite file text:

Talk-Group Rewrite was conceived as a way of making talk-groups behave more 
like the reflector system and of attempting to solve the problem of "slot 
contention",where the user may be locked out of a slot by traffic on a 
talk-group they know nothing about, without knowing why. This is frustrating to 
users, both those new to DMR and seasoned DMR users. 

TG Rewrite, when enabled for a slot, rewrites the DST ID of incoming talkgroup 
traffic to TG9, alowing audio to be heard by any user monitoring TG9 on that 
slot. If the user then replies on TG9, as long as they key-up during the 
CallHang period, the DST ID (TG) is again rewritten on the outbound traffic, 
which transparently maps back to the originating talkgroup. Rewrite is also 
enabled if an outbound call is made to a talkgroup and then TG9 is activated 
during the CallHang period. 

To use a User Activated talk-group, briefly key-up on that talk-group to 
activate it, then switch back to TG9 and talk as normal. If the CallHang period 
expires, you may need to activate the talk-group again by keying up on that 
talkgroup briefly, as before. Alternatively, you can wait for inbound audio to 
re-activate the rewrite, then respond during the CallHang period. 

Note, proper ettiquette dictates that the user confirms the repeater is free 
before activiating this feature. It is best to ensure the slot is keyed from 
"cold" when activating a talkgroup for rewrite. Although not strictly 
neccesary, it may be advantageous to also disconnect the repeater from the 
reflector system first, if using slot 2.

Talk-group rewrite was originally intended to work with User-Activated talk 
groups, although it will function with permanent talk-groups too. 

It is useful to set the CallHang parameter to a generous amount. I am currently 
using seven seconds. 


Two boolean configuration options control the TG Rewrite feature:

TGRewriteSlot1=[0|1]
TGRewriteSlot2=[0|1]

ACL's are applied before the rewrite, so still apply to rewritten traffic on 
original (non-rewritten) talk-group. 

73

Simon (G7RZU)