### PR TITLE
Display CW activity on displays

### DIFF
--- a/Defines.h
+++ b/Defines.h
@@ -23,6 +23,7 @@ const unsigned char MODE_IDLE    = 0U;
 const unsigned char MODE_DSTAR   = 1U;
 const unsigned char MODE_DMR     = 2U;
 const unsigned char MODE_YSF     = 3U;
+const unsigned char MODE_CW      = 4U;
 const unsigned char MODE_LOCKOUT = 99U;
 const unsigned char MODE_ERROR   = 100U;
 

--- a/Display.cpp
+++ b/Display.cpp
@@ -155,6 +155,11 @@ void CDisplay::clearFusion()
 	}
 }
 
+void CDisplay::writeCW()
+{
+	writeCWInt();
+}
+
 void CDisplay::clock(unsigned int ms)
 {
 	m_timer1.clock(ms);

--- a/Display.cpp
+++ b/Display.cpp
@@ -157,6 +157,9 @@ void CDisplay::clearFusion()
 
 void CDisplay::writeCW()
 {
+	m_timer1.start();
+	m_mode1 = MODE_CW;
+
 	writeCWInt();
 }
 
@@ -177,6 +180,11 @@ void CDisplay::clock(unsigned int ms)
 			break;
 		case MODE_YSF:
 			clearFusionInt();
+			m_mode1 = MODE_IDLE;
+			m_timer1.stop();
+			break;
+		case MODE_CW:
+			clearCWInt();
 			m_mode1 = MODE_IDLE;
 			m_timer1.stop();
 			break;

--- a/Display.h
+++ b/Display.h
@@ -45,6 +45,7 @@ public:
 	void clearFusion();
 
 	void writeCW();
+	void clearCW();
 
 	virtual void close() = 0;
 
@@ -65,6 +66,7 @@ protected:
 	virtual void clearFusionInt() = 0;
 
 	virtual void writeCWInt() = 0;
+	virtual void clearCWInt() = 0;
 
 	virtual void clockInt(unsigned int ms);
 

--- a/Display.h
+++ b/Display.h
@@ -44,6 +44,8 @@ public:
 	void writeFusion(const char* source, const char* dest, const char* type, const char* origin);
 	void clearFusion();
 
+	void writeCW();
+
 	virtual void close() = 0;
 
 	void clock(unsigned int ms);
@@ -61,6 +63,8 @@ protected:
 
 	virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin) = 0;
 	virtual void clearFusionInt() = 0;
+
+	virtual void writeCWInt() = 0;
 
 	virtual void clockInt(unsigned int ms);
 

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -730,6 +730,18 @@ void CHD44780::clearFusionInt()
 	}
 }
 
+void CHD44780::writeCWInt()
+{
+	::lcdPosition(m_fd, m_cols - 5, m_rows - 1);
+	::lcdPuts(m_fd, "CW TX");
+}
+
+void CHD44780::clearCWInt()
+{
+	::lcdPosition(m_fd, m_cols - 5, m_rows - 1);
+	::lcdPuts(m_fd, " Idle");
+}
+
 void CHD44780::clockInt(unsigned int ms)
 {
 	m_clockDisplayTimer.clock(ms);

--- a/HD44780.h
+++ b/HD44780.h
@@ -110,6 +110,9 @@ protected:
   virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
   virtual void clearFusionInt();
 
+  virtual void writeCWInt();
+  virtual void clearCWInt();
+
   virtual void clockInt(unsigned int ms);
 
 private:

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -619,8 +619,8 @@ int CMMDVMHost::run()
 		if (m_cwIdTimer.isRunning() && m_cwIdTimer.hasExpired()) {
 			if (m_mode == MODE_IDLE && !m_modem->hasTX()){
 				LogDebug("sending CW ID");
+				m_display->writeCW();
 				m_modem->sendCWId(m_callsign);
-				m_display->setIdle();
 
 				m_cwIdTimer.start();   //reset only after sending ID, timer-overflow after 49 days doesnt matter
 			}

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -620,6 +620,7 @@ int CMMDVMHost::run()
 			if (m_mode == MODE_IDLE && !m_modem->hasTX()){
 				LogDebug("sending CW ID");
 				m_modem->sendCWId(m_callsign);
+				m_display->setIdle();
 
 				m_cwIdTimer.start();   //reset only after sending ID, timer-overflow after 49 days doesnt matter
 			}

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -245,6 +245,15 @@ void CNextion::writeCWInt()
 
        sendCommand(command);
        sendCommand("t1.txt=\"Sending CW Ident\"");
+
+	m_clockDisplayTimer.stop();
+
+	m_mode = MODE_CW;
+}
+
+void CNextion::clearCWInt()
+{
+	setIdleInt();
 }
 
 void CNextion::clockInt(unsigned int ms)

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -235,9 +235,7 @@ void CNextion::clearFusionInt()
 
 void CNextion::writeCWInt()
 {
-       char command[30];
-
-       sendCommand("t1.txt=\"Sending CW Ident\"");
+	sendCommand("t1.txt=\"Sending CW Ident\"");
 
 	m_clockDisplayTimer.stop();
 

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -233,6 +233,20 @@ void CNextion::clearFusionInt()
 	sendCommand("t2.txt=\"\"");
 }
 
+void CNextion::sendCWInt()
+{
+       sendCommand("page MMDVM");
+
+       char command[30];
+       ::sprintf(command, "dim=%u", m_brightness);
+       sendCommand(command);
+
+       ::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign.c_str(), m_dmrid);
+
+       sendCommand(command);
+       sendCommand("t1.txt=\"Sending CW Ident\"");
+}
+
 void CNextion::clockInt(unsigned int ms)
 {
 	// Update the clock display in IDLE mode every 400ms

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -233,7 +233,7 @@ void CNextion::clearFusionInt()
 	sendCommand("t2.txt=\"\"");
 }
 
-void CNextion::sendCWInt()
+void CNextion::writeCWInt()
 {
        sendCommand("page MMDVM");
 

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -235,8 +235,6 @@ void CNextion::clearFusionInt()
 
 void CNextion::writeCWInt()
 {
-       sendCommand("page MMDVM");
-
        char command[30];
 
        ::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign.c_str(), m_dmrid);

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -237,9 +237,6 @@ void CNextion::writeCWInt()
 {
        char command[30];
 
-       ::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign.c_str(), m_dmrid);
-
-       sendCommand(command);
        sendCommand("t1.txt=\"Sending CW Ident\"");
 
 	m_clockDisplayTimer.stop();
@@ -249,7 +246,7 @@ void CNextion::writeCWInt()
 
 void CNextion::clearCWInt()
 {
-	setIdleInt();
+	sendCommand("t1.txt=\"MMDVM IDLE\"");
 }
 
 void CNextion::clockInt(unsigned int ms)

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -238,8 +238,6 @@ void CNextion::writeCWInt()
        sendCommand("page MMDVM");
 
        char command[30];
-       ::sprintf(command, "dim=%u", m_brightness);
-       sendCommand(command);
 
        ::sprintf(command, "t0.txt=\"%-6s / %u\"", m_callsign.c_str(), m_dmrid);
 

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -237,7 +237,7 @@ void CNextion::writeCWInt()
 {
 	sendCommand("t1.txt=\"Sending CW Ident\"");
 
-	m_clockDisplayTimer.stop();
+	m_clockDisplayTimer.start();
 
 	m_mode = MODE_CW;
 }
@@ -251,7 +251,7 @@ void CNextion::clockInt(unsigned int ms)
 {
 	// Update the clock display in IDLE mode every 400ms
 	m_clockDisplayTimer.clock(ms);
-	if (m_displayClock && m_mode == MODE_IDLE && m_clockDisplayTimer.isRunning() && m_clockDisplayTimer.hasExpired()) {
+	if (m_displayClock && (m_mode == MODE_IDLE || m_mode == MODE_CW) && m_clockDisplayTimer.isRunning() && m_clockDisplayTimer.hasExpired()) {
 		time_t currentTime;
 		struct tm *Time;
 		::time(&currentTime);                   // Get the current time

--- a/Nextion.h
+++ b/Nextion.h
@@ -50,6 +50,8 @@ protected:
   virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
   virtual void clearFusionInt();
 
+  virtual void sendCWInt();
+
   virtual void clockInt(unsigned int ms);
 
 private:

--- a/Nextion.h
+++ b/Nextion.h
@@ -50,7 +50,7 @@ protected:
   virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
   virtual void clearFusionInt();
 
-  virtual void sendCWInt();
+  virtual void writeCWInt();
 
   virtual void clockInt(unsigned int ms);
 

--- a/Nextion.h
+++ b/Nextion.h
@@ -51,6 +51,7 @@ protected:
   virtual void clearFusionInt();
 
   virtual void writeCWInt();
+  virtual void clearCWInt();
 
   virtual void clockInt(unsigned int ms);
 

--- a/NullDisplay.cpp
+++ b/NullDisplay.cpp
@@ -72,6 +72,10 @@ void CNullDisplay::writeCWInt()
 {
 }
 
+void CNullDisplay::clearCWInt()
+{
+}
+
 void CNullDisplay::close()
 {
 }

--- a/NullDisplay.cpp
+++ b/NullDisplay.cpp
@@ -68,6 +68,10 @@ void CNullDisplay::clearFusionInt()
 {
 }
 
+void CNullDisplay::writeCWInt()
+{
+}
+
 void CNullDisplay::close()
 {
 }

--- a/NullDisplay.h
+++ b/NullDisplay.h
@@ -47,6 +47,8 @@ protected:
 	virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
 	virtual void clearFusionInt();
 
+	virtual void writeCWInt();
+
 private:
 };
 

--- a/NullDisplay.h
+++ b/NullDisplay.h
@@ -48,6 +48,7 @@ protected:
 	virtual void clearFusionInt();
 
 	virtual void writeCWInt();
+	virtual void clearCWInt();
 
 private:
 };

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -313,10 +313,16 @@ void CTFTSerial::clearFusionInt()
 
 void CTFTSerial::writeCWInt()
 {
+	gotoPosPixel(45U, 90U);
+	displayText("CW TX");
+
+	m_mode = MODE_CW;
 }
 
 void CTFTSerial::clearCWInt()
 {
+	gotoPosPixel(45U, 90U);
+	displayText("IDLE");
 }
 
 void CTFTSerial::close()

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -311,6 +311,10 @@ void CTFTSerial::clearFusionInt()
 	displayText("              ");
 }
 
+void CTFTSerial::writeCWInt()
+{
+}
+
 void CTFTSerial::close()
 {
 	m_serial.close();

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -315,6 +315,10 @@ void CTFTSerial::writeCWInt()
 {
 }
 
+void CTFTSerial::clearCWInt()
+{
+}
+
 void CTFTSerial::close()
 {
 	m_serial.close();

--- a/TFTSerial.h
+++ b/TFTSerial.h
@@ -49,6 +49,8 @@ protected:
 	virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
 	virtual void clearFusionInt();
 
+	virtual void writeCWInt();
+
 private:
    std::string       m_callsign;
    unsigned int      m_dmrid;

--- a/TFTSerial.h
+++ b/TFTSerial.h
@@ -50,6 +50,7 @@ protected:
 	virtual void clearFusionInt();
 
 	virtual void writeCWInt();
+	virtual void clearCWInt();
 
 private:
    std::string       m_callsign;


### PR DESCRIPTION
This is to change the Idle Page to leave a small note if MMDVM is transmitting the CW ID.