### PR TITLE
Change conflicting ports

### DIFF
--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -122,8 +122,8 @@ Debug=0
 [P25 Network]
 Enable=1
 GatewayAddress=127.0.0.1
-GatewayPort=20010
-LocalPort=20011
+GatewayPort=20012
+LocalPort=20013
 Debug=0
 
 [TFT Serial]


### PR DESCRIPTION
With D-Star and P25 Network enabled at least D-Star stops working. This is obviously due to the same port being used. Just changed the P25 ports to 20012 and 20013 in order to make the default MMDVM.ini working. Confirmed by @m1geo.