### PR TITLE
Changed default P25 Network ports to match P25Gateway

### DIFF
--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -124,8 +124,8 @@ Debug=0
 [P25 Network]
 Enable=1
 GatewayAddress=127.0.0.1
-GatewayPort=20012
-LocalPort=20013
+GatewayPort=42020
+LocalPort=32010
 Debug=0
 
 [TFT Serial]


### PR DESCRIPTION
The ports for P25 Network in MMDVM were set by Flo when the previous ones conflicted with YSFGateway. These ports make the default match the default for the P25Gateway.

George M1GEO