### PR TITLE
Correct missing methods in OLED.h

### DIFF
--- a/HD44780.h
+++ b/HD44780.h
@@ -110,8 +110,8 @@ protected:
   virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
   virtual void clearFusionInt();
 
-	virtual void writeP25Int(const char* source, bool group, unsigned int dest, const char* type);
-	virtual void clearP25Int();
+  virtual void writeP25Int(const char* source, bool group, unsigned int dest, const char* type);
+  virtual void clearP25Int();
 
   virtual void writeCWInt();
   virtual void clearCWInt();

--- a/OLED.h
+++ b/OLED.h
@@ -94,8 +94,8 @@ public:
   virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
   virtual void clearFusionInt();
 
-	virtual void writeP25Int(const char* source, bool group, unsigned int dest, const char* type);
-	virtual void clearP25Int();
+  virtual void writeP25Int(const char* source, bool group, unsigned int dest, const char* type);
+  virtual void clearP25Int();
 
   virtual void writeCWInt();$
   virtual void clearCWInt();

--- a/OLED.h
+++ b/OLED.h
@@ -97,6 +97,9 @@ public:
 	virtual void writeP25Int(const char* source, bool group, unsigned int dest, const char* type);
 	virtual void clearP25Int();
 
+  virtual void writeCWInt();$
+  virtual void clearCWInt();
+
   virtual void close();
 
 private:


### PR DESCRIPTION
Referencing issue from MMDVM Yahoo group: https://groups.yahoo.com/neo/groups/mmdvm/conversations/topics/8841
Seems like the CWIdent methods were missing in OLED.h