### PR TITLE
Correct compiling with LCDproc and Adafruit/HD44780 displays

### DIFF
--- a/LCDproc.cpp
+++ b/LCDproc.cpp
@@ -48,8 +48,8 @@ unsigned int   m_cols(0);
 bool           m_screensDefined(false);
 bool           m_connected(false);
 
-char           m_displaybuffer1[BUFFER_MAX_LEN];
-char           m_displaybuffer2[BUFFER_MAX_LEN];
+char           m_displayBuffer1[BUFFER_MAX_LEN];
+char           m_displayBuffer2[BUFFER_MAX_LEN];
 
 CLCDproc::CLCDproc(std::string address, unsigned int port, unsigned int localPort, const std::string& callsign, unsigned int dmrid, bool displayClock, bool utc, bool duplex, bool dimOnIdle) :
 CDisplay(),
@@ -180,26 +180,26 @@ void CLCDproc::writeDStarInt(const char* my1, const char* my2, const char* your,
 	socketPrintf(m_socketfd, "screen_set DStar -priority foreground");
 	socketPrintf(m_socketfd, "widget_set DStar Mode 1 1 \"D-Star\"");
 
-	::sprintf(m_displaybuffer1, "%.8s", your);
+	::sprintf(m_displayBuffer1, "%.8s", your);
 	
-	char *p = m_displaybuffer1;
+	char *p = m_displayBuffer1;
 	for (; *p; ++p) {
 		if (*p == ' ')
 			*p = '_';
 	}
 
 	if (strcmp(reflector, "        ") != 0) {
-		sprintf(m_displaybuffer2, " via %.8s", reflector);
+		sprintf(m_displayBuffer2, " via %.8s", reflector);
 	} else {
-		//bzero(m_displaybuffer2, BUFFER_MAX_LEN);
-		memset(m_displaybuffer2, 0, BUFFER_MAX_LEN);
+		//bzero(m_displayBuffer2, BUFFER_MAX_LEN);
+		memset(m_displayBuffer2, 0, BUFFER_MAX_LEN);
 	}
 
 	if (m_rows == 2) {
-		socketPrintf(m_socketfd, "widget_set DStar Line2 1 2 %u 2 h 3 \"%.8s/%.4s to %s%s\"", m_cols - 1, my1, my2, m_displaybuffer1, m_displaybuffer2);
+		socketPrintf(m_socketfd, "widget_set DStar Line2 1 2 %u 2 h 3 \"%.8s/%.4s to %s%s\"", m_cols - 1, my1, my2, m_displayBuffer1, m_displayBuffer2);
 	} else {
 		socketPrintf(m_socketfd, "widget_set DStar Line2 1 2 %u 2 h 3 \"%.8s/%.4s\"", m_cols - 1, my1, my2);
-		socketPrintf(m_socketfd, "widget_set DStar Line3 1 3 %u 3 h 3 \"%s%s\"", m_cols - 1, m_displaybuffer1, m_displaybuffer2);
+		socketPrintf(m_socketfd, "widget_set DStar Line3 1 3 %u 3 h 3 \"%s%s\"", m_cols - 1, m_displayBuffer1, m_displayBuffer2);
 	}
 
 	m_dmr = false;
@@ -367,14 +367,14 @@ void CLCDproc::clockInt(unsigned int ms)
 		}
 			
 		setlocale(LC_TIME,"");
-		strftime(m_displaybuffer1, 128, "%X", Time);  // Time
-		strftime(m_displaybuffer2, 128, "%x", Time);  // Date
+		strftime(m_displayBuffer1, 128, "%X", Time);  // Time
+		strftime(m_displayBuffer2, 128, "%x", Time);  // Date
 
 		if (m_cols < 26U && m_rows == 2U) {
-			socketPrintf(m_socketfd, "widget_set Status Time %u 2 \"%s%s\"", m_cols - 9, strlen(m_displaybuffer1) > 8 ? "" : "  ", m_displaybuffer1);
+			socketPrintf(m_socketfd, "widget_set Status Time %u 2 \"%s%s\"", m_cols - 9, strlen(m_displayBuffer1) > 8 ? "" : "  ", m_displayBuffer1);
 		} else {
-			socketPrintf(m_socketfd, "widget_set Status Time %u %u \"%s\"", (m_cols - (strlen(m_displaybuffer1) == 8 ? 6 : 8)) / 2, m_rows / 2, m_displaybuffer1);
-			socketPrintf(m_socketfd, "widget_set Status Date %u %u \"%s\"", (m_cols - (strlen(m_displaybuffer1) == 8 ? 6 : 8)) / 2, m_rows / 2 + 1, m_displaybuffer2);
+			socketPrintf(m_socketfd, "widget_set Status Time %u %u \"%s\"", (m_cols - (strlen(m_displayBuffer1) == 8 ? 6 : 8)) / 2, m_rows / 2, m_displayBuffer1);
+			socketPrintf(m_socketfd, "widget_set Status Date %u %u \"%s\"", (m_cols - (strlen(m_displayBuffer1) == 8 ? 6 : 8)) / 2, m_rows / 2 + 1, m_displayBuffer2);
 		}
 
 		m_clockDisplayTimer.start();
@@ -465,15 +465,15 @@ void CLCDproc::clockInt(unsigned int ms)
 						} else if (0 == strcmp(argv[0], "success")) {
 							//LogDebug("LCDproc, command successful");
 						} else if (0 == strcmp(argv[0], "huh?")) {
-							sprintf(m_displaybuffer1, "LCDproc, command failed:");
-							sprintf(m_displaybuffer2, " ");
+							sprintf(m_displayBuffer1, "LCDproc, command failed:");
+							sprintf(m_displayBuffer2, " ");
 
 							int j;
 							for (j = 1; j < argc; j++) {
-								strcat(m_displaybuffer1, m_displaybuffer2);
-								strcat(m_displaybuffer1, argv[j]);
+								strcat(m_displayBuffer1, m_displayBuffer2);
+								strcat(m_displayBuffer1, argv[j]);
 							}
-							LogDebug("%s", m_displaybuffer1);
+							LogDebug("%s", m_displayBuffer1);
 						}
 					}
 

--- a/LCDproc.cpp
+++ b/LCDproc.cpp
@@ -48,8 +48,8 @@ unsigned int   m_cols(0);
 bool           m_screensDefined(false);
 bool           m_connected(false);
 
-char           m_buffer1[BUFFER_MAX_LEN];
-char           m_buffer2[BUFFER_MAX_LEN];
+char           m_displaybuffer1[BUFFER_MAX_LEN];
+char           m_displaybuffer2[BUFFER_MAX_LEN];
 
 CLCDproc::CLCDproc(std::string address, unsigned int port, unsigned int localPort, const std::string& callsign, unsigned int dmrid, bool displayClock, bool utc, bool duplex, bool dimOnIdle) :
 CDisplay(),
@@ -180,26 +180,26 @@ void CLCDproc::writeDStarInt(const char* my1, const char* my2, const char* your,
 	socketPrintf(m_socketfd, "screen_set DStar -priority foreground");
 	socketPrintf(m_socketfd, "widget_set DStar Mode 1 1 \"D-Star\"");
 
-	::sprintf(m_buffer1, "%.8s", your);
+	::sprintf(m_displaybuffer1, "%.8s", your);
 	
-	char *p = m_buffer1;
+	char *p = m_displaybuffer1;
 	for (; *p; ++p) {
 		if (*p == ' ')
 			*p = '_';
 	}
 
 	if (strcmp(reflector, "        ") != 0) {
-		sprintf(m_buffer2, " via %.8s", reflector);
+		sprintf(m_displaybuffer2, " via %.8s", reflector);
 	} else {
-		//bzero(m_buffer2, BUFFER_MAX_LEN);
-		memset(m_buffer2, 0, BUFFER_MAX_LEN);
+		//bzero(m_displaybuffer2, BUFFER_MAX_LEN);
+		memset(m_displaybuffer2, 0, BUFFER_MAX_LEN);
 	}
 
 	if (m_rows == 2) {
-		socketPrintf(m_socketfd, "widget_set DStar Line2 1 2 %u 2 h 3 \"%.8s/%.4s to %s%s\"", m_cols - 1, my1, my2, m_buffer1, m_buffer2);
+		socketPrintf(m_socketfd, "widget_set DStar Line2 1 2 %u 2 h 3 \"%.8s/%.4s to %s%s\"", m_cols - 1, my1, my2, m_displaybuffer1, m_displaybuffer2);
 	} else {
 		socketPrintf(m_socketfd, "widget_set DStar Line2 1 2 %u 2 h 3 \"%.8s/%.4s\"", m_cols - 1, my1, my2);
-		socketPrintf(m_socketfd, "widget_set DStar Line3 1 3 %u 3 h 3 \"%s%s\"", m_cols - 1, m_buffer1, m_buffer2);
+		socketPrintf(m_socketfd, "widget_set DStar Line3 1 3 %u 3 h 3 \"%s%s\"", m_cols - 1, m_displaybuffer1, m_displaybuffer2);
 	}
 
 	m_dmr = false;
@@ -367,14 +367,14 @@ void CLCDproc::clockInt(unsigned int ms)
 		}
 			
 		setlocale(LC_TIME,"");
-		strftime(m_buffer1, 128, "%X", Time);  // Time
-		strftime(m_buffer2, 128, "%x", Time);  // Date
+		strftime(m_displaybuffer1, 128, "%X", Time);  // Time
+		strftime(m_displaybuffer2, 128, "%x", Time);  // Date
 
 		if (m_cols < 26U && m_rows == 2U) {
-			socketPrintf(m_socketfd, "widget_set Status Time %u 2 \"%s%s\"", m_cols - 9, strlen(m_buffer1) > 8 ? "" : "  ", m_buffer1);
+			socketPrintf(m_socketfd, "widget_set Status Time %u 2 \"%s%s\"", m_cols - 9, strlen(m_displaybuffer1) > 8 ? "" : "  ", m_displaybuffer1);
 		} else {
-			socketPrintf(m_socketfd, "widget_set Status Time %u %u \"%s\"", (m_cols - (strlen(m_buffer1) == 8 ? 6 : 8)) / 2, m_rows / 2, m_buffer1);
-			socketPrintf(m_socketfd, "widget_set Status Date %u %u \"%s\"", (m_cols - (strlen(m_buffer1) == 8 ? 6 : 8)) / 2, m_rows / 2 + 1, m_buffer2);
+			socketPrintf(m_socketfd, "widget_set Status Time %u %u \"%s\"", (m_cols - (strlen(m_displaybuffer1) == 8 ? 6 : 8)) / 2, m_rows / 2, m_displaybuffer1);
+			socketPrintf(m_socketfd, "widget_set Status Date %u %u \"%s\"", (m_cols - (strlen(m_displaybuffer1) == 8 ? 6 : 8)) / 2, m_rows / 2 + 1, m_displaybuffer2);
 		}
 
 		m_clockDisplayTimer.start();
@@ -465,15 +465,15 @@ void CLCDproc::clockInt(unsigned int ms)
 						} else if (0 == strcmp(argv[0], "success")) {
 							//LogDebug("LCDproc, command successful");
 						} else if (0 == strcmp(argv[0], "huh?")) {
-							sprintf(m_buffer1, "LCDproc, command failed:");
-							sprintf(m_buffer2, " ");
+							sprintf(m_displaybuffer1, "LCDproc, command failed:");
+							sprintf(m_displaybuffer2, " ");
 
 							int j;
 							for (j = 1; j < argc; j++) {
-								strcat(m_buffer1, m_buffer2);
-								strcat(m_buffer1, argv[j]);
+								strcat(m_displaybuffer1, m_displaybuffer2);
+								strcat(m_displaybuffer1, argv[j]);
 							}
-							LogDebug("%s", m_buffer1);
+							LogDebug("%s", m_displaybuffer1);
 						}
 					}
 

--- a/Makefile.Pi.Adafruit
+++ b/Makefile.Pi.Adafruit
@@ -9,9 +9,9 @@ LDFLAGS = -g -L/usr/local/lib
 OBJECTS = \
 		AMBEFEC.o BCH.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRLookup.o DMRLC.o \
 		DMRNetwork.o DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o \
-		Golay24128.o Hamming.o HD44780.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
-		P25Network.o P25NID.o P25Utils.o QR1676.o RS129.o RS241213.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o \
-		Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
+		Golay24128.o Hamming.o HD44780.o LCDproc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o \
+		P25LowSpeedData.o P25Network.o P25NID.o P25Utils.o QR1676.o RS129.o RS241213.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o \
+		Timer.o UDPSocket.o Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 
 all:		MMDVMHost
 

--- a/Makefile.Pi.HD44780
+++ b/Makefile.Pi.HD44780
@@ -9,7 +9,7 @@ LDFLAGS = -g -L/usr/local/lib
 OBJECTS = \
 		AMBEFEC.o BCH.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRLookup.o DMRLC.o \
 		DMRNetwork.o DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o \
-		Golay24128.o Hamming.o HD44780.o LCDProc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
+		Golay24128.o Hamming.o HD44780.o LCDproc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
 		P25Network.o P25NID.o P25Utils.o QR1676.o RS129.o RS241213.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o \
 		Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 

--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -9,7 +9,7 @@ LDFLAGS = -g -L/usr/local/lib
 OBJECTS = \
 		AMBEFEC.o BCH.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRLookup.o DMRLC.o \
 		DMRNetwork.o DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o \
-		Golay24128.o Hamming.o OLED.o LCDProc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
+		Golay24128.o Hamming.o OLED.o LCDproc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
 		P25Network.o P25NID.o P25Utils.o QR1676.o RS129.o RS241213.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o \
 		Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 

--- a/Makefile.Pi.PCF8574
+++ b/Makefile.Pi.PCF8574
@@ -9,7 +9,7 @@ LDFLAGS = -g -L/usr/local/lib
 OBJECTS = \
 		AMBEFEC.o BCH.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRLookup.o DMRLC.o \
 		DMRNetwork.o DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o \
-		Golay24128.o Hamming.o HD44780.o LCDProc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
+		Golay24128.o Hamming.o HD44780.o LCDproc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
 		P25Network.o P25NID.o P25Utils.o QR1676.o RS129.o RS241213.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o \
 		Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 

--- a/Makefile.Solaris
+++ b/Makefile.Solaris
@@ -9,7 +9,7 @@ LDFLAGS = -g
 OBJECTS = \
 		AMBEFEC.o BCH.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedLC.o DMRFullLC.o DMRLookup.o DMRLC.o \
 		DMRNetwork.o DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o DStarSlowData.o Golay2087.o \
-		Golay24128.o Hamming.o LCDProc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
+		Golay24128.o Hamming.o LCDproc.o Log.o MMDVMHost.o Modem.o ModemSerialPort.o Mutex.o Nextion.o NullDisplay.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o \
 		P25Network.o P25NID.o P25Utils.o QR1676.o RS129.o RS241213.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o Timer.o UDPSocket.o \
 		Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o
 


### PR DESCRIPTION
The variables in LCDproc.cpp clash with the ones of the same name in HD44780.cpp when both display types are to be compiled in. That happens when compiling with Makefile.Pi.Adafruit for example. The variables m_buffer1 and m_buffer2 in LCDproc.cpp have been renamed to m_displayBuffer1 and m_displayBuffer2. 
In addition I corrected the typos in Makefile.Pi.HD44780, Makefile.Pi.OLED and Makefile.Pi.PCF8574.
I tested all Makefiles on a Raspberry Pi except the Solaris one.