### PR TITLE
Fix OLED header file (ref. b69336d)

### DIFF
--- a/OLED.h
+++ b/OLED.h
@@ -37,7 +37,7 @@
 class COLED : public CDisplay 
 {
 public:
-  COLED(unsigned char displayType, unsigned char displayBrighness, unsigned char displayInvert);
+  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert);
   virtual ~COLED();
 
   virtual bool open();


### PR DESCRIPTION
Compiling for OLED results in an error:

```
OLED.cpp:59:1: error: prototype for ‘COLED::COLED(unsigned char, unsigned char, bool)’ does not match any in class ‘COLED’
 COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert) :
 ^
In file included from OLED.cpp:19:0:
OLED.h:37:7: error: candidates are: constexpr COLED::COLED(const COLED&)
 class COLED : public CDisplay 
       ^
OLED.h:40:3: error:                 COLED::COLED(unsigned char, unsigned char, unsigned char)
   COLED(unsigned char displayType, unsigned char displayBrighness, unsigned char displayInvert);
   ^
Makefile.Pi.OLED:22: recipe for target 'OLED.o' failed
make: *** [OLED.o] Error 1
```

Changed displayInvert to cool in header file. 