### PR TITLE
Add proper error handling to nextion.py

### DIFF
--- a/Nextion/nextion.py
+++ b/Nextion/nextion.py
@@ -105,9 +105,10 @@ if __name__ == "__main__":
         \nnote: model name is optional'
         exit(1)
 
-    ser = serial.Serial(sys.argv[2], 9600, timeout=5)
-    if not ser:
-        print 'could not open device'
+    try:
+        ser = serial.Serial(sys.argv[2], 9600, timeout=5)
+    except serial.serialutil.SerialException:
+        print 'could not open serial device ' + sys.argv[2]
         exit(1)
     if not ser.is_open:
         ser.open()

--- a/Nextion/nextion.py
+++ b/Nextion/nextion.py
@@ -20,6 +20,7 @@ import serial
 import time
 import sys
 import os
+import re
 
 e = "\xff\xff\xff"
 
@@ -116,4 +117,8 @@ if __name__ == "__main__":
     checkModel = None
     if len(sys.argv) == 4:
         checkModel = sys.argv[3]
+        pattern = re.compile("^NX\d{4}[TK]\d{3}$")
+        if not pattern.match(checkModel):
+            print 'Invalid model name. Please give a correct one (e.g. NX3224T024)'
+            exit(1)
     upload(ser, sys.argv[1], checkModel)


### PR DESCRIPTION
If the serial device is not present or in use the code fails with a traceback. This adds some proper error handling for these cases.

```
$ python nextion.py MMDVM_3.5.tft /dev/ttyUSB9
Traceback (most recent call last):
  File "nextion.py", line 108, in <module>
    ser = serial.Serial(sys.argv[2], 9600, timeout=5)
  File "/usr/lib/python2.7/dist-packages/serial/serialutil.py", line 180, in __init__
    self.open()
  File "/usr/lib/python2.7/dist-packages/serial/serialposix.py", line 294, in open
    raise SerialException(msg.errno, "could not open port %s: %s" % (self._port, msg))
serial.serialutil.SerialException: [Errno 2] could not open port /dev/ttyUSB9: [Errno 2] No such file or directory: '/dev/ttyUSB9'
```

Also added a regex to check for correct model number/name if given.