### PR TITLE
Make nextion.py compatible with pyserial < v3

### DIFF
--- a/Nextion/nextion.py
+++ b/Nextion/nextion.py
@@ -111,8 +111,12 @@ if __name__ == "__main__":
     except serial.serialutil.SerialException:
         print 'could not open serial device ' + sys.argv[2]
         exit(1)
-    if not ser.is_open:
-        ser.open()
+    if (serial.VERSION <= "3.0"):
+        if not ser.isOpen():
+            ser.open()
+    else:
+        if not ser.is_open:
+            ser.open()
 
     checkModel = None
     if len(sys.argv) == 4:


### PR DESCRIPTION
nextion.py fails on latest Raspbian Jessie due to outdated pyserial. The method "is_open" does not exist in pyserial < 3. This adds a simple version check and applies the correct methods. Error message was:

```
  File "nextion.py", line 114, in <module>
    if not ser.is_open:
AttributeError: 'Serial' object has no attribute 'is_open'
```
