### PR TITLE
Update HD44780 information

### DIFF
--- a/HD44780.md
+++ b/HD44780.md
@@ -1,9 +1,0 @@
-G0WFV's HD44780 todo list ...
-
-As I only have a 2x16 screen at the moment, development has been done based
-on this size screen.  Where it is simple, I have attempted ***but not tested***
-to implement functions for larger screens.
-
-Here's a list of things I would like to accomplish in the near future ...
-
-- Nothing planned at this time!  Any suggestions?

--- a/README.HD44780
+++ b/README.HD44780
@@ -6,6 +6,45 @@ http://wiringpi.com/download-and-install/ which must be installed in all cases.
 The HD44780 in 4-bit mode is probably the most common connection method and
 wiring details can be found at http://wiringpi.com/dev-lib/lcd-library/
 
+The setup that is commonly used for MMDVM is the 4-bit connection that is also
+documented within wiringPi. The HD44780 displays have a standardized 16-pin
+connector (14 pins if without backlight). The pin numbers on HD44780 refer to
+this standard numbering.
+
+The pin numbers on Raspberry Pi side are the physical pin numbers of the GPIO
+pin header, in brackets the wiringPi pin number as these are referred to in the
+MMDVM.ini file.
+
+The wiring ist as follows:
+
+ HD44780 pin    Raspberry Pi GPIO
+  GND  1  --------   6 GND
+  VCC  2  --------   2 +5V
+  V0   3  --------     Trimmer between +5V and GND for contrast
+  RS   4  --------  26 CE1 (11)
+  RW   5  --------   6 GND
+  E    6  --------  24 CE0 (10)
+  D0   7
+  D1   8
+  D2   9
+  D3  10
+  D4  11  --------  11 GPIO0 (0)
+  D5  12  --------  12 GPIO1 (1)
+  D6  13  --------  13 GPIO2 (2)
+  D7  14  --------  15 GPIO3 (3)
+  GND 15  --------   6 GND
+  VCC 16  --------   2 +5V
+
+The relevant part in the MMDVM.ini is like outlined below.
+
+[HD44780]
+Rows=4
+Columns=20
+
+# For basic HD44780 displays (4-bit connection)
+# rs, strb, d0, d1, d2, d3
+Pins=11,10,0,1,2,3
+
 To compile MMDVMHost with support for the HD44780 use the following commands.
 
 # cp Makefile.Pi.HD44780 Makefile

--- a/README.HD44780
+++ b/README.HD44780
@@ -47,9 +47,8 @@ Pins=11,10,0,1,2,3
 
 To compile MMDVMHost with support for the HD44780 use the following commands.
 
-# cp Makefile.Pi.HD44780 Makefile
 # make clean
-# make
+# make -f Makefile.Pi.HD44780
 
 Other HD44780 variations exist that connect via I2C. Support is also via 
 wiringPi, but to compile for each I2C device requires a different Makefile 


### PR DESCRIPTION
As aligend with @g0wfv I deleted the HD44780.md as it contains no useful information for the user and instead updated README.HD44780 with some information about how to wire the HD44780 to the RPi.