### PR TITLE
Add LED for CD function to UMP

### DIFF
--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -452,6 +452,8 @@ int CMMDVMHost::run()
 		if (m_ump != NULL) {
 			bool tx = m_modem->hasTX();
 			m_ump->setTX(tx);
+			bool cd = m_modem->hasCD();
+			m_ump->setCD(cd);
 		}
 
 		unsigned char data[200U];

--- a/Modem.cpp
+++ b/Modem.cpp
@@ -128,6 +128,7 @@ m_dmrSpace2(0U),
 m_ysfSpace(0U),
 m_p25Space(0U),
 m_tx(false),
+m_cd(false),
 m_lockout(false),
 m_error(false),
 m_hwType(HWT_UNKNOWN)
@@ -446,8 +447,10 @@ void CModem::clock(unsigned int ms)
 					m_ysfSpace   = m_buffer[9U];
 					m_p25Space   = m_buffer[10U];
 
+					m_cd = (m_buffer[11U] & 0x01U) == 0x01U;
+
 					m_inactivityTimer.start();
-					// LogMessage("status=%02X, tx=%d, space=%u,%u,%u,%u,%u lockout=%d", m_buffer[5U], int(m_tx), m_dstarSpace, m_dmrSpace1, m_dmrSpace2, m_ysfSpace, m_p25Space, int(m_lockout));
+					// LogMessage("status=%02X, tx=%d, space=%u,%u,%u,%u,%u lockout=%d, cd=%d", m_buffer[5U], int(m_tx), m_dstarSpace, m_dmrSpace1, m_dmrSpace2, m_ysfSpace, m_p25Space, int(m_lockout), int(m_cd));
 				}
 				break;
 
@@ -850,6 +853,11 @@ bool CModem::writeSerial(const unsigned char* data, unsigned int length)
 bool CModem::hasTX() const
 {
 	return m_tx;
+}
+
+bool CModem::hasCD() const
+{
+	return m_cd;
 }
 
 bool CModem::hasLockout() const

--- a/Modem.h
+++ b/Modem.h
@@ -59,6 +59,7 @@ public:
 	bool hasP25Space() const;
 
 	bool hasTX() const;
+	bool hasCD() const;
 
 	bool hasLockout() const;
 	bool hasError() const;
@@ -131,6 +132,7 @@ private:
 	unsigned int               m_ysfSpace;
 	unsigned int               m_p25Space;
 	bool                       m_tx;
+	bool                       m_cd;
 	bool                       m_lockout;
 	bool                       m_error;
 	HW_TYPE                    m_hwType;

--- a/UMP.cpp
+++ b/UMP.cpp
@@ -31,6 +31,7 @@ const unsigned char UMP_HELLO        = 0x00U;
 
 const unsigned char UMP_SET_MODE     = 0x01U;
 const unsigned char UMP_SET_TX       = 0x02U;
+const unsigned char UMP_SET_CD       = 0x03U;
 
 const unsigned char UMP_WRITE_SERIAL = 0x10U;
 const unsigned char UMP_READ_SERIAL  = 0x11U;
@@ -47,7 +48,8 @@ m_length(0U),
 m_offset(0U),
 m_lockout(false),
 m_mode(MODE_IDLE),
-m_tx(false)
+m_tx(false),
+m_cd(false)
 {
 	m_buffer = new unsigned char[BUFFER_LENGTH];
 }
@@ -118,6 +120,25 @@ bool CUMP::setTX(bool on)
 	buffer[0U] = UMP_FRAME_START;
 	buffer[1U] = 4U;
 	buffer[2U] = UMP_SET_TX;
+	buffer[3U] = on ? 0x01U : 0x00U;
+
+	// CUtils::dump(1U, "Transmitted", buffer, 4U);
+
+	return m_serial.write(buffer, 4U) == 4;
+}
+
+bool CUMP::setCD(bool on)
+{
+	if (on == m_cd)
+		return true;
+
+	m_cd = on;
+
+	unsigned char buffer[4U];
+
+	buffer[0U] = UMP_FRAME_START;
+	buffer[1U] = 4U;
+	buffer[2U] = UMP_SET_CD;
 	buffer[3U] = on ? 0x01U : 0x00U;
 
 	// CUtils::dump(1U, "Transmitted", buffer, 4U);

--- a/UMP.h
+++ b/UMP.h
@@ -36,6 +36,8 @@ public:
 
 	bool setTX(bool on);
 
+	bool setCD(bool on);
+
 	bool getLockout() const;
 
 	virtual int read(unsigned char* buffer, unsigned int length);
@@ -55,6 +57,7 @@ private:
 	bool              m_lockout;
 	unsigned char     m_mode;
 	bool              m_tx;
+	bool              m_cd;
 };
 
 #endif

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -27,6 +27,8 @@
 
 #define PIN_TX      6
 
+#define PIN_CD      8
+
 #define PIN_LOCKOUT 7
 
 // Use the LOCKOUT function on the UMP
@@ -46,6 +48,7 @@ void setup()
   pinMode(PIN_YSF,     OUTPUT);
   pinMode(PIN_P25,     OUTPUT);
   pinMode(PIN_TX,      OUTPUT);
+  pinMode(PIN_CD,      OUTPUT);
   pinMode(PIN_LOCKOUT, INPUT);
 
   digitalWrite(PIN_DSTAR, LOW);
@@ -53,6 +56,7 @@ void setup()
   digitalWrite(PIN_YSF,   LOW);
   digitalWrite(PIN_P25,   LOW);
   digitalWrite(PIN_TX,    LOW);
+  digitalWrite(PIN_CD,    LOW);
 }
 
 #define UMP_FRAME_START   0xF0U
@@ -61,6 +65,7 @@ void setup()
 
 #define UMP_SET_MODE      0x01U
 #define UMP_SET_TX        0x02U
+#define UMP_SET_CD        0x03U
 
 #define UMP_WRITE_SERIAL  0x10U
 
@@ -112,6 +117,9 @@ void loop()
           break;
         case UMP_SET_TX:
           digitalWrite(PIN_TX, m_buffer[3U] == 0x01U ? HIGH : LOW);
+          break;
+        case UMP_SET_CD:
+          digitalWrite(PIN_CD, m_buffer[3U] == 0x01U ? HIGH : LOW);
           break;
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
         case UMP_WRITE_SERIAL:

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -27,9 +27,9 @@
 
 #define PIN_TX      6
 
-#define PIN_CD      8
+#define PIN_CD      7
 
-#define PIN_LOCKOUT 7
+#define PIN_LOCKOUT 8
 
 // Use the LOCKOUT function on the UMP
 // #define USE_LOCKOUT


### PR DESCRIPTION
Added one more LED to let the UMP be able  to signalize when MMDVMHost detected a valid carrier. The information is hooked from the MMDVM CD function that also drives the ZUM onboard LED.