### PR TITLE
Possible fix of loop after Internet down (DMR)?

### DIFF
--- a/DMRNetwork.cpp
+++ b/DMRNetwork.cpp
@@ -559,7 +559,6 @@ bool CDMRNetwork::write(const unsigned char* data, unsigned int length)
 	bool ret = m_socket.write(data, length, m_address, m_port);
 	if (!ret) {
 		LogError("DMR, Socket has failed when writing data to the master, retrying connection");
-		close();
 		open();
 		return false;
 	}

--- a/DMRNetwork.cpp
+++ b/DMRNetwork.cpp
@@ -559,6 +559,7 @@ bool CDMRNetwork::write(const unsigned char* data, unsigned int length)
 	bool ret = m_socket.write(data, length, m_address, m_port);
 	if (!ret) {
 		LogError("DMR, Socket has failed when writing data to the master, retrying connection");
+		m_socket.close();
 		open();
 		return false;
 	}


### PR DESCRIPTION
CDMRNetwork::close() generate more socket writes, therefore we have a loop. I replaced with a socket close(). Please check!