### PR TITLE
UMP: Allow boards without a second hardware UART to host the Nextion Display

### DIFF
--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -17,7 +17,7 @@
 */
 
 #if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__) && !defined(__MK20DX256__)
-#include <SoftwareSerial.h>
+#include <AltSoftSerial.h>
 #endif
 
 #if !defined(PIN_LED)
@@ -45,16 +45,13 @@
 #define PIN_TX      6
 #define PIN_CD      7
 
-#define PIN_LOCKOUT 8
+#define PIN_LOCKOUT 10
 
 #define FLASH_DELAY 3200U
 #endif
 
 #if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__) && !defined(__MK20DX256__)
-#define SOFT_SERIAL_TX  9
-#define SOFT_SERIAL_RX 10
-
-SoftwareSerial mySerial(SOFT_SERIAL_RX, SOFT_SERIAL_TX); // RX, TX
+AltSoftSerial mySerial;
 #endif
 
 // Use the LOCKOUT function on the UMP

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -45,7 +45,7 @@
 #define PIN_TX      6
 #define PIN_CD      7
 
-#define PIN_LOCKOUT 10
+#define PIN_LOCKOUT 12
 
 #define FLASH_DELAY 3200U
 #endif

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -16,20 +16,28 @@
 *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__)
+#include <SoftwareSerial.h>
+#endif
+
 #if !defined(PIN_LED)
 #define PIN_LED     13
 #endif
 
-#define PIN_DSTAR   2
-#define PIN_DMR     3 
-#define PIN_YSF     4
-#define PIN_P25     5
+#define PIN_DSTAR       2
+#define PIN_DMR         3
+#define PIN_YSF         4
+#define PIN_P25         5
 
-#define PIN_TX      6
+#define PIN_TX          6
+#define PIN_CD          7
 
-#define PIN_CD      7
+#define PIN_LOCKOUT     8
 
-#define PIN_LOCKOUT 8
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__)
+#define SOFT_SERIAL_TX  9
+#define SOFT_SERIAL_RX 10
+#endif
 
 // Use the LOCKOUT function on the UMP
 // #define USE_LOCKOUT
@@ -40,6 +48,9 @@ void setup()
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
   Serial1.begin(9600);
+#else
+	SoftwareSerial mySerial(SOFT_SERIAL_RX, SOFT_SERIAL_TX); // RX, TX
+	mySerial.begin(9600);
 #endif
 
   pinMode(PIN_LED,     OUTPUT);
@@ -121,11 +132,13 @@ void loop()
         case UMP_SET_CD:
           digitalWrite(PIN_CD, m_buffer[3U] == 0x01U ? HIGH : LOW);
           break;
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
         case UMP_WRITE_SERIAL:
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
           Serial1.write(m_buffer + 3U, m_length - 3U);
-          break;
+#else
+					mySerial.write(m_buffer + 3U, m_length - 3U);
 #endif
+          break;
         default:
           break;
         }
@@ -154,6 +167,9 @@ void loop()
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
   while (Serial1.available())
     Serial1.read();
+#else
+	while (mySerial.available())
+		mySerial.read();
 #endif
 
   m_count++;

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -16,7 +16,7 @@
 *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__)
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__) && !defined(__MK20DX256__)
 #include <SoftwareSerial.h>
 #endif
 
@@ -45,7 +45,8 @@
 
 #define PIN_LOCKOUT 8
 #endif
-#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__)
+
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__) && !defined(__MK20DX256__)
 #define SOFT_SERIAL_TX  9
 #define SOFT_SERIAL_RX 10
 

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -37,6 +37,8 @@
 #if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__) && !defined(__AVR_ATmega32U4__) && !defined(__SAM3X8E__)
 #define SOFT_SERIAL_TX  9
 #define SOFT_SERIAL_RX 10
+
+SoftwareSerial mySerial(SOFT_SERIAL_RX, SOFT_SERIAL_TX); // RX, TX
 #endif
 
 // Use the LOCKOUT function on the UMP
@@ -49,7 +51,6 @@ void setup()
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
   Serial1.begin(9600);
 #else
-	SoftwareSerial mySerial(SOFT_SERIAL_RX, SOFT_SERIAL_TX); // RX, TX
 	mySerial.begin(9600);
 #endif
 

--- a/UMP/UMP.ino
+++ b/UMP/UMP.ino
@@ -51,7 +51,7 @@ void setup()
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
   Serial1.begin(9600);
 #else
-	mySerial.begin(9600);
+  mySerial.begin(9600);
 #endif
 
   pinMode(PIN_LED,     OUTPUT);
@@ -137,7 +137,7 @@ void loop()
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__SAM3X8E__)
           Serial1.write(m_buffer + 3U, m_length - 3U);
 #else
-					mySerial.write(m_buffer + 3U, m_length - 3U);
+          mySerial.write(m_buffer + 3U, m_length - 3U);
 #endif
           break;
         default:
@@ -169,8 +169,8 @@ void loop()
   while (Serial1.available())
     Serial1.read();
 #else
-	while (mySerial.available())
-		mySerial.read();
+  while (mySerial.available())
+    mySerial.read();
 #endif
 
   m_count++;
@@ -188,4 +188,3 @@ void loop()
     }
   }
 }
-


### PR DESCRIPTION
Uses the AltSoftSerial library (http://www.pjrc.com/teensy/td_libs_AltSoftSerial.html) which is available through (and needs to be installed with) the Arduino IDE library manager.

Serial Tx/Rx pins are unfortunately hard coded in this library and can be found in the link above, but on Uno, Duemilanove, LilyPad, Mini, Nano (& other ATMEGA328 boards) the pins are Tx - 9 and Rx - 8.  Consequently the lockout pin has been moved to Pin 12 to avoid possible Tx/Rx pins for this library on all boards.

Thanks to @phl0 for the testing :)