### PR TITLE
Add sample RSSI.dat files with pre-measured values

### DIFF
--- a/RSSI/RSSI_GM340.dat
+++ b/RSSI/RSSI_GM340.dat
@@ -1,0 +1,42 @@
+# This file maps the raw RSSI values to dBm values to send to the DMR network. A number of data
+# points should be entered and the software will use those to work out the in-between values.
+#
+# The format of the file is:
+# Raw RSSI Value		dBm Value
+#
+# Measured with a Marconi 2955 Test set and Motorola GM340 UHF (430.6125 MHz).
+# Both S-meter (6dB) and decade (10dB) steps are included between the noise floor and saturation.
+# George M1GEO / GB7KH - 01/01/2017
+#
+2841		-20
+2848		-30
+2854		-40
+2858		-43
+2858		-48
+2853		-50
+2845		-53
+2780		-58
+2732		-60
+2647		-63
+2484		-68
+2422		-70
+2356		-73
+2234		-78
+2183		-80
+2103		-83
+1978		-88
+1931		-90
+1875		-93
+1710		-99
+1686		-100
+1545		-105
+1416		-110
+1398		-111
+1238		-117
+1166		-120
+1106		-123
+1018		-129
+1006		-130
+985		-135
+976		-140
+971		-150

--- a/RSSI/RSSI_TB7100.dat
+++ b/RSSI/RSSI_TB7100.dat
@@ -1,0 +1,48 @@
+# This file maps the raw RSSI values to dBm values to send to the DMR network. A number of data
+# points should be entered and the software will use those to work out the in-between values.
+#
+# The format of the file is:
+# Raw RSSI Value		dBm Value		#output voltage
+#
+# The following values were measured with a Marconi 2024 signal generator.
+# Setup is MMDVM (PCB by Toufik, F0DEI) on a STM32F446RE Nucleo board.
+# The values in the comments are the voltage measured at the TB7100 RSSI output pin.
+# Florian DF2ET, 03.03.2017
+#
+2303		-22		#2.93
+2256		-25		#2.86
+2184		-28		#2.77
+2159		-31		#2.74
+2095		-34		#2.66
+2040		-37		#2.59
+1985		-40		#2.52
+1922		-43		#2.44
+1868		-46		#2.37
+1804		-49		#2.29
+1758		-52		#2.23
+1694		-55		#2.15
+1640		-58		#2.08
+1568		-61		#1.99
+1540		-64		#1.95
+1459		-67		#1.85
+1403		-70		#1.78
+1340		-73		#1.70
+1287		-76		#1.63
+1233		-79		#1.56
+1178		-82		#1.49
+1116		-85		#1.41
+1054		-88		#1.33
+1000		-91		#1.27
+945		-94		#1.20
+890		-97		#1.13
+830		-100		#1.05
+768		-103		#0.97
+715		-106		#0.90
+660		-109		#0.83
+600		-112		#0.76
+540		-115		#0.68
+500		-118		#0.63
+450		-121		#0.57
+420		-124		#0.52
+390		-127		#0.48
+370		-130		#0.47


### PR DESCRIPTION
How about adding RSSI.dat files with sample values for different rigs? 
I addded the one for Motorola GM3x0 by @m1geo and a new one that I created a few days ago for a Tait TB7100 and a MMDVM on STM32F446 Board.