### PR TITLE
Added git commit version ID to MMDVMHost startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ MMDVMHost
 *.VC.db
 .vs
 *.ambe
-gitversion.h
+GitVersion.h

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ MMDVMHost
 *.VC.db
 .vs
 *.ambe
+gitversion.h

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -33,7 +33,7 @@
 #include "LCDproc.h"
 #include "Thread.h"
 #include "Log.h"
-#include "gitversion.h"
+#include "GitVersion.h"
 
 #if defined(HD44780)
 #include "HD44780.h"

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -33,6 +33,7 @@
 #include "LCDproc.h"
 #include "Thread.h"
 #include "Log.h"
+#include "gitversion.h"
 
 #if defined(HD44780)
 #include "HD44780.h"
@@ -235,6 +236,7 @@ int CMMDVMHost::run()
 	LogInfo(HEADER4);
 
 	LogMessage("MMDVMHost-%s is starting", VERSION);
+	LogMessage("Built %s %s (GitID #%.7s)", __TIME__, __DATE__, gitversion);
 
 	readParams();
 

--- a/MMDVMHost.vcxproj
+++ b/MMDVMHost.vcxproj
@@ -108,6 +108,12 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PreBuildEvent>
+      <Command>"$(ProjectDir)prebuild.cmd" $(ProjectDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>prebuild.cmd generates GitVersion.h from git refs heads master</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
- 
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/Makefile.Pi
+++ b/Makefile.Pi
@@ -15,12 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
- 
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/Makefile.Pi.Adafruit
+++ b/Makefile.Pi.Adafruit
@@ -15,12 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS)
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
- 
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/Makefile.Pi.HD44780
+++ b/Makefile.Pi.HD44780
@@ -15,12 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
- 
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -15,12 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
- 
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/Makefile.Pi.PCF8574
+++ b/Makefile.Pi.PCF8574
@@ -15,11 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/Makefile.Solaris
+++ b/Makefile.Solaris
@@ -15,12 +15,19 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	$(OBJECTS)
+MMDVMHost:	gitversion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~
- 
+		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+
+# Export the current git version if the index file exists, else 000...
+gitversion.h:
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/prebuild.cmd
+++ b/prebuild.cmd
@@ -29,7 +29,7 @@ for /f %%i in ('type !HASHFILE!') do set GITHASH=%%i
 goto :WRITEGITVERSIONHEADER
 
 :WRITEGITVERSIONHEADER
-echo # File contains Git commit ID SHA1 present at buildtime (prebuild.cmd) > GitVersion.h
+echo // File contains Git commit ID SHA1 present at buildtime (prebuild.cmd) > GitVersion.h
 echo const char *gitversion = "%GITHASH%"; >> GitVersion.h
 echo Current Git HASH: %GITHASH%
 goto :FINISHED

--- a/prebuild.cmd
+++ b/prebuild.cmd
@@ -1,0 +1,38 @@
+@echo off
+REM This pre-build file is for MSVS VC++. It parses the git master hash and
+REM converts it into GitVersion.h for compiling into builds. [George M1GEO]
+
+cd %1
+setlocal enabledelayedexpansion
+set HEADFILE=.git\HEAD
+set HASHFILE=0
+if exist %HEADFILE% (
+	for /F "tokens=4 delims=/:" %%a in ('type %HEADFILE%') do set HEADBRANCH=%%a	
+	set HASHFILE=.git\refs\heads\!HEADBRANCH!
+	echo Found Git HEAD file: %HEADFILE%   
+	echo Git HEAD branch: !HEADBRANCH!
+	echo Git HASH file: !HASHFILE!
+	call :USEHASH
+) else (
+	echo No head file :(
+	call :USENULL
+)
+
+goto :EOF
+
+:USENULL
+set GITHASH=0000000000000000000000000000000000000000
+goto :WRITEGITVERSIONHEADER
+
+:USEHASH
+for /f %%i in ('type !HASHFILE!') do set GITHASH=%%i
+goto :WRITEGITVERSIONHEADER
+
+:WRITEGITVERSIONHEADER
+echo # File contains Git commit ID SHA1 present at buildtime (prebuild.cmd) > GitVersion.h
+echo const char *gitversion = "%GITHASH%"; >> GitVersion.h
+echo Current Git HASH: %GITHASH%
+goto :FINISHED
+
+:FINISHED
+echo GitVersion.h written...


### PR DESCRIPTION
I have added the git commit version ID to MMDVMHost at startup. This way it is easy to see exactly which version of the source-code your host was built from. I was having trouble debugging something and I couldn't see if I had rebuilt after pulling/pushing/etc. Now, when MMDVMHost starts, there's an extra message: 

> I: 2017-03-10 03:53:25.551 Copyright(C) 2015, 2016 by Jonathan Naylor, G4KLX and others
> M: 2017-03-10 03:53:25.551 MMDVMHost-20170303 is starting
> M: 2017-03-10 03:53:25.551 Built 03:41:26 Mar 10 2017 (GitID #ef89ffe)
> I: 2017-03-10 03:53:25.551 General Parameters
> I: 2017-03-10 03:53:25.551     Callsign: G9BF

It's probably easier to just look at the diff files on this pull request, but here's what happened:


1) Create GitVersion.h file inside all Makefiles
	a) Added GitVersion.h which depends on .git/HEAD and .git/index
	b) Added GitVersion.h to MMDVMHost dependencies, before $(OBJECTS)
	c) Added GitVersion.h to RM command for git clean
	d) Added code to check if ".git/index" exists. If not, #0000000 is used.
	
2) Create GitVersion.h file inside MSVS
	a) Created prebuild.cmd, reads .git\HEAD for current branch, then .git\refs\heads\%BRANCH%
	b) Inserted prebuild.cmd into pre-build of MMDVMHost.vcxproj for MSVS
	c) prebuild.cmd generates GitVersion.h on Windows. 
		i) It takes one argument, the MMDVMHost source folder path.
		ii) If argument omitted, assumes current dir.
	
3) Added GitVersion.h to .gitignore

4) Added GitVersion.h to includes in MMDVMHost.cpp

5) Added Build Timestamp and 7-character git commit number to LogMessage at startup

6) Took reasonable precaution and tested on both Windows (MSVS 2017) and Linux --  See pictures attached.

_The MMDVM Firmware timestamp depends on the MMDVM PR being accepted._

George M1GEO

![mmdvmhost_win_gengitversion](https://cloud.githubusercontent.com/assets/758615/23781808/c2ea5608-0547-11e7-9e8e-aa0047295e2d.png)
![mmdvmhost_win_built](https://cloud.githubusercontent.com/assets/758615/23781809/c2f0aae4-0547-11e7-98dc-70a4c2e0fe0a.png)
![mmdvmhost_win_buildinfo](https://cloud.githubusercontent.com/assets/758615/23781810/c2fbb998-0547-11e7-8b39-0e7bb82746f3.png)
![mmdvmhost_win_modeminfo](https://cloud.githubusercontent.com/assets/758615/23781811/c303fd24-0547-11e7-9927-e70b1ccecb07.png)
![mmdvmhost_lin_gengitversion](https://cloud.githubusercontent.com/assets/758615/23781812/c30d217e-0547-11e7-84c3-7dbe09a53e24.png)
![mmdvmhost_lin_built](https://cloud.githubusercontent.com/assets/758615/23781813/c316a44c-0547-11e7-84f1-d29d5e647dc4.png)
![mmdvmhost_lin_buildinfo](https://cloud.githubusercontent.com/assets/758615/23781814/c3263484-0547-11e7-840a-6c498111e870.png)
![mmdvmhost_lin_modeminfo](https://cloud.githubusercontent.com/assets/758615/23781815/c330022a-0547-11e7-96ef-923ac1bd40e8.png)

George M1GEO