### PR TITLE
Fix case errors with GitVersion.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS) 
+MMDVMHost:	GitVersion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
 else

--- a/Makefile.Pi
+++ b/Makefile.Pi
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS) 
+MMDVMHost:	GitVersion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
 else

--- a/Makefile.Pi.Adafruit
+++ b/Makefile.Pi.Adafruit
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS)
+MMDVMHost:	GitVersion.h $(OBJECTS)
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
 else

--- a/Makefile.Pi.HD44780
+++ b/Makefile.Pi.HD44780
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS) 
+MMDVMHost:	GitVersion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
 else

--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS) 
+MMDVMHost:	GitVersion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
 else

--- a/Makefile.Pi.PCF8574
+++ b/Makefile.Pi.PCF8574
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS) 
+MMDVMHost:	GitVersion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
 else

--- a/Makefile.Solaris
+++ b/Makefile.Solaris
@@ -15,17 +15,17 @@ OBJECTS = \
 
 all:		MMDVMHost
 
-MMDVMHost:	gitversion.h $(OBJECTS) 
+MMDVMHost:	GitVersion.h $(OBJECTS) 
 		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
 clean:
-		$(RM) MMDVMHost *.o *.d *.bak *~ gitversion.h
+		$(RM) MMDVMHost *.o *.d *.bak *~ GitVersion.h
 
 # Export the current git version if the index file exists, else 000...
-gitversion.h:
+GitVersion.h:
 ifneq ("$(wildcard .git/index)","")
 	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
 else


### PR DESCRIPTION
Changed all occurences of "gitversion.h" to "GitVersion.h" in Makefiles because MMDVMHost.cpp includes "GitVersion.h" and not "gitversion.h". This is a difference at least on file systems that are case sensitive.