### PR TITLE
This adds the ability to override the UID checking in P25 code to for…

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -145,6 +145,7 @@ m_p25GatewayAddress(),
 m_p25GatewayPort(0U),
 m_p25LocalPort(0U),
 m_p25NetworkDebug(false),
+m_p25OverrideUID(false),
 m_tftSerialPort("/dev/ttyAMA0"),
 m_tftSerialBrightness(50U),
 m_hd44780Rows(2U),
@@ -494,6 +495,8 @@ bool CConf::read()
 			m_p25LocalPort = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "Debug") == 0)
 			m_p25NetworkDebug = ::atoi(value) == 1;
+		else if (::strcmp(key, "OverrideUIDCheck") == 0)
+			m_p25OverrideUID = ::atoi(value) == 1;
 	} else if (section == SECTION_TFTSERIAL) {
 		if (::strcmp(key, "Port") == 0)
 			m_tftSerialPort = value;
@@ -1018,6 +1021,11 @@ unsigned int CConf::getP25LocalPort() const
 bool CConf::getP25NetworkDebug() const
 {
 	return m_p25NetworkDebug;
+}
+
+bool CConf::getP25OverrideUID() const
+{
+	return m_p25OverrideUID;
 }
 
 std::string CConf::getTFTSerialPort() const

--- a/Conf.h
+++ b/Conf.h
@@ -150,6 +150,7 @@ public:
   unsigned int getP25GatewayPort() const;
   unsigned int getP25LocalPort() const;
   bool         getP25NetworkDebug() const;
+  bool         getP25OverrideUID() const;
 
   // The TFTSERIAL section
   std::string  getTFTSerialPort() const;
@@ -294,6 +295,7 @@ private:
   unsigned int m_p25GatewayPort;
   unsigned int m_p25LocalPort;
   bool         m_p25NetworkDebug;
+  bool         m_p25OverrideUID;
 
   std::string  m_tftSerialPort;
   unsigned int m_tftSerialBrightness;

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -120,6 +120,7 @@ GatewayAddress=127.0.0.1
 GatewayPort=42020
 LocalPort=32010
 Debug=0
+OverrideUIDCheck=0
 
 [TFT Serial]
 # Port=modem

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -412,7 +412,7 @@ int CMMDVMHost::run()
 		LogInfo("P25 Parameters");
 		LogInfo("    NAC: $%03X", nac);
 
-		p25 = new CP25Control(nac, m_p25Network, m_display, m_timeout, m_duplex, m_lookup, rssi);
+		p25 = new CP25Control(nac, m_conf.getP25OverrideUID(), m_p25Network, m_display, m_timeout, m_duplex, m_lookup, rssi);
 	}
 
 	setMode(MODE_IDLE);

--- a/P25Control.cpp
+++ b/P25Control.cpp
@@ -35,8 +35,9 @@ const unsigned char BIT_MASK_TABLE[] = {0x80U, 0x40U, 0x20U, 0x10U, 0x08U, 0x04U
 #define WRITE_BIT(p,i,b) p[(i)>>3] = (b) ? (p[(i)>>3] | BIT_MASK_TABLE[(i)&7]) : (p[(i)>>3] & ~BIT_MASK_TABLE[(i)&7])
 #define READ_BIT(p,i)    (p[(i)>>3] & BIT_MASK_TABLE[(i)&7])
 
-CP25Control::CP25Control(unsigned int nac, CP25Network* network, CDisplay* display, unsigned int timeout, bool duplex, CDMRLookup* lookup, CRSSIInterpolator* rssiMapper) :
+CP25Control::CP25Control(unsigned int nac, bool uidoverride, CP25Network* network, CDisplay* display, unsigned int timeout, bool duplex, CDMRLookup* lookup, CRSSIInterpolator* rssiMapper) :
 m_nac(nac),
+m_uidoverride(uidoverride),
 m_network(network),
 m_display(display),
 m_duplex(duplex),
@@ -176,7 +177,7 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 	if (duid == P25_DUID_LDU1) {
 		if (m_rfState == RS_RF_LISTENING) {
 			m_rfData.reset();
-			bool ret = m_rfData.decodeLDU1(data + 2U);
+			bool ret = m_rfData.decodeLDU1(data + 2U, m_network, m_uidoverride);
 			if (!ret) {
 				m_lastDUID = duid;
 				return false;

--- a/P25Control.h
+++ b/P25Control.h
@@ -36,7 +36,7 @@
 
 class CP25Control {
 public:
-	CP25Control(unsigned int nac, CP25Network* network, CDisplay* display, unsigned int timeout, bool duplex, CDMRLookup* lookup, CRSSIInterpolator* rssiMapper);
+	CP25Control(unsigned int nac, bool uidoverride, CP25Network* network, CDisplay* display, unsigned int timeout, bool duplex, CDMRLookup* lookup, CRSSIInterpolator* rssiMapper);
 	~CP25Control();
 
 	bool writeModem(unsigned char* data, unsigned int len);
@@ -47,6 +47,7 @@ public:
 
 private:
 	unsigned int               m_nac;
+	bool                       m_uidoverride;
 	CP25Network*               m_network;
 	CDisplay*                  m_display;
 	bool                       m_duplex;

--- a/P25Data.cpp
+++ b/P25Data.cpp
@@ -71,7 +71,7 @@ void CP25Data::encodeHeader(unsigned char* data)
 	CP25Utils::encode(DUMMY_HEADER, data, 114U, 780U);
 }
 
-bool CP25Data::decodeLDU1(const unsigned char* data)
+bool CP25Data::decodeLDU1(const unsigned char* data, bool m_network, bool m_uidoverride)
 {
 	assert(data != NULL);
 
@@ -105,11 +105,12 @@ bool CP25Data::decodeLDU1(const unsigned char* data)
 		return false;
 	}
 
-	// Simple validation of the source id
+		// Simple validation of the source id - does not check if no network
 	unsigned int srcId = (rs[6U] << 16) + (rs[7U] << 8) + rs[8U];
-	if (srcId < 1000000U)
-		return false;
-
+	if(m_network || (!m_network && !m_uidoverride))  {
+		if (srcId < 1000000U)
+			return false;
+	}
 	switch (rs[0U]) {
 	case P25_LCF_GROUP:
 		m_emergency = (rs[2U] & 0x80U) == 0x80U;

--- a/P25Data.h
+++ b/P25Data.h
@@ -28,7 +28,7 @@ public:
 
 	void encodeHeader(unsigned char* data);
 
-	bool decodeLDU1(const unsigned char* data);
+	bool decodeLDU1(const unsigned char* data, bool m_network, bool m_overrideuid);
 	void encodeLDU1(unsigned char* data);
 
 	void encodeLDU2(unsigned char* data);

--- a/P25Network.cpp
+++ b/P25Network.cpp
@@ -433,3 +433,5 @@ void CP25Network::enable(bool enabled)
 {
 	m_enabled = enabled;
 }
+
+


### PR DESCRIPTION
…ce 7 digit IDs.

Jonathan added this code due to a lack of CRC on P25 checking but some parties desire the ability to have any id.

It's understood that on networked connections, the need to use a 7 digit unique ID like the DMR ID is necessary.

This change is affected by adding a new parameter to the [P25 Network] section called OverrideUIDCheck and it defaults to 0.

The logic is, if the network is enabled, or if the network is disabled and the override is disabled, the check is made, otherwise it is not.

This has been field tested for all 4 configuration cases and found to work as described above.