### PR TITLE
RT8 GPS Data.

### DIFF
--- a/DMRDataHeader.cpp
+++ b/DMRDataHeader.cpp
@@ -126,13 +126,13 @@ bool CDMRDataHeader::put(const unsigned char* bytes)
 		break;
 	}
 
-	if (dpf == DPF_UDT && m_blocks == 0U) {
-		unsigned char format = m_data[1U] & 0x0FU;
-		if (format == UDTF_NMEA) {
-			LogDebug("DMR, fixing broken Tytera MD-390 GPS data block count");
-			m_blocks = 3U;
-		}
-	}
+	//if (dpf == DPF_UDT && m_blocks == 0U) {
+	//	unsigned char format = m_data[1U] & 0x0FU;
+	//	if (format == UDTF_NMEA) {
+	//		LogDebug("DMR, fixing broken Tytera MD-390 GPS data block count");
+	//		m_blocks = 3U;
+	//	}
+	//}
 
 	return true;
 }

--- a/DMRDataHeader.cpp
+++ b/DMRDataHeader.cpp
@@ -126,6 +126,8 @@ bool CDMRDataHeader::put(const unsigned char* bytes)
 		break;
 	}
 
+	// Any Value other than 0 generates an "Invalid CRC-16 checksum" on BM Servers.
+	// Tested on RT8 with md380-tools S13.020 5840962 2017-05-15
 	//if (dpf == DPF_UDT && m_blocks == 0U) {
 	//	unsigned char format = m_data[1U] & 0x0FU;
 	//	if (format == UDTF_NMEA) {

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -410,6 +410,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 		} else if (dataType == DT_RATE_12_DATA) {
 			if (m_rfState == RS_RF_DATA)
 				return true;
+			// Tested on RT8 with md380-tools S13.020 5840962 2017-05-15
 			LogMessage("DT_RATE_12_DATA Packet received");
 			
 			char latSign[2];

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -377,7 +377,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 
 			if ( ((payload[1U] & 0x05U) == 0x05U) && ((payload[8U] & 0x03U) == 0x00U) )
 				{
-					LogDebug("UDT/NMEA Frame, Slot %d, 1 Appended data block to come.", m_slotNo, srcId, dstId);
+					LogDebug("UDT/NMEA Frame, Slot %d, 1 Appended data block outstanding, storing Src %d, Dst %d", m_slotNo, srcId, dstId);
 					// Store Source and destination ID's  per slot
 					if (m_slotNo == 1)
 					{	
@@ -495,10 +495,8 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 
 			// Convert the Data Sync to be from the BS or MS as needed
 			CSync::addDMRDataSync(data + 2U, m_duplex);
-
-			m_rfFrames--;
-
-			data[0U] = m_rfFrames == 0U ? TAG_EOT : TAG_DATA;
+			
+			data[0U] = TAG_EOT;
 			data[1U] = 0x00U;
 
 			if (m_duplex)

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -431,10 +431,6 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			else
 				strcpy(lonSign,"W");
 			
-			if ((payload[0U] & 0x10U) >> 4)
-			 	LogDebug("GPS Fix");
-			else
-				LogDebug("NoGPS Fix");
 
 
 			uint8_t latDeg = ((payload[1U] & 0x1F) << 2) + ((payload[2U] & 0xC0) >> 6);
@@ -443,13 +439,21 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			uint8_t lonDeg = ((payload[4U] & 0x03) << 6) + ((payload[5U] & 0xFC) >> 2);
 			uint8_t lonMin = ((payload[5U] & 0x03) << 4) + ((payload[6U] & 0xF0) >> 4);
 			uint32_t lonSec = ((payload[6U] & 0x0F) << 8) + (payload[7U] << 2) + ((payload[8U] & 0xA0) >>6);
-		    
-			LogDebug("UTC Hour %d", (payload[8U] & 0x3E) >> 1);
-			LogDebug("UTC Minute %d", ((payload[8U] & 0x01) << 5) + ((payload[9U] & 0xF4) >> 3));
-			LogDebug("UTC Second %d", (payload[9U] & 0x03)* 10);
+		    uint8_t alt = ( ((payload[8U] & 0x3F) << 8 ) + payload[9U]);  
 
-			LogDebug("Result is %02d %02d.%d%s, %d %d.%d%s ", latDeg, latMin, latSec,latSign,
-		    							                      lonDeg, lonMin, lonSec,lonSign);
+
+			//LogDebug("UTC Hour %d", (payload[8U] & 0x3E) >> 1);
+			//LogDebug("ALT %d", alt);  
+			//LogDebug("UTC Minute (?) %d", ((payload[8U] & 0x01) << 5) + ((payload[9U] & 0xF4) >> 3));
+			//LogDebug("UTC Second (?) %d", (payload[9U] & 0x03)* 10);
+
+			if ((payload[0U] & 0x10U) >> 4){
+			 	LogDebug("GPS Fix");
+			 	LogDebug("Position: %02d %02d.%03d%s, %03d %02d.%03d%s at Alt of %dm", latDeg, latMin, latSec,latSign,
+		    							                      lonDeg, lonMin, lonSec, lonSign, alt);
+			}
+			else
+				LogDebug("No GPS Fix");
 
 			return true;
 		} else if (dataType == DT_CSBK) {

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -432,21 +432,13 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			else
 				strcpy(lonSign,"W");
 			
-
-
 			uint8_t latDeg = ((payload[1U] & 0x1F) << 2) + ((payload[2U] & 0xC0) >> 6);
 			uint8_t latMin = payload[2U] & 0x6F;
 			int32_t latSec = (payload[3U] << 6) + (payload[4U] & 0xFC);
 			uint8_t lonDeg = ((payload[4U] & 0x03) << 6) + ((payload[5U] & 0xFC) >> 2);
 			uint8_t lonMin = ((payload[5U] & 0x03) << 4) + ((payload[6U] & 0xF0) >> 4);
 			uint32_t lonSec = ((payload[6U] & 0x0F) << 8) + (payload[7U] << 2) + ((payload[8U] & 0xA0) >>6);
-		    uint8_t alt = ( ((payload[8U] & 0x3F) << 8 ) + payload[9U]);  
-
-
-			//LogDebug("UTC Hour %d", (payload[8U] & 0x3E) >> 1);
-			//LogDebug("ALT %d", alt);  
-			//LogDebug("UTC Minute (?) %d", ((payload[8U] & 0x01) << 5) + ((payload[9U] & 0xF4) >> 3));
-			//LogDebug("UTC Second (?) %d", (payload[9U] & 0x03)* 10);
+			uint8_t alt = ( ((payload[8U] & 0x3F) << 8 ) + payload[9U]);  
 
 			if ((payload[0U] & 0x10U) >> 4){
 			 	LogDebug("GPS Fix");

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -438,17 +438,17 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 
 
 			uint8_t latDeg = ((payload[1U] & 0x1F) << 2) + ((payload[2U] & 0xC0) >> 6);
-		    uint8_t latMin = payload[2U] & 0x6F;
-		    int32_t latSec = (payload[3U] << 6) + (payload[4U] & 0xFC);
-		    uint8_t lonDeg = ((payload[4U] & 0x03) << 6) + ((payload[5U] & 0xFC) >> 2);
-		    uint8_t lonMin = ((payload[5U] & 0x03) << 4) + ((payload[6U] & 0xF0) >> 4);
-		    uint32_t lonSec = ((payload[6U] & 0x0F) << 8) + (payload[7U] << 2) + ((payload[8U] & 0xA0) >>6);
+			uint8_t latMin = payload[2U] & 0x6F;
+			int32_t latSec = (payload[3U] << 6) + (payload[4U] & 0xFC);
+			uint8_t lonDeg = ((payload[4U] & 0x03) << 6) + ((payload[5U] & 0xFC) >> 2);
+			uint8_t lonMin = ((payload[5U] & 0x03) << 4) + ((payload[6U] & 0xF0) >> 4);
+			uint32_t lonSec = ((payload[6U] & 0x0F) << 8) + (payload[7U] << 2) + ((payload[8U] & 0xA0) >>6);
 		    
-		    LogDebug("UTC Hour %d", (payload[8U] & 0x3E) >> 1);
+			LogDebug("UTC Hour %d", (payload[8U] & 0x3E) >> 1);
 			LogDebug("UTC Minute %d", ((payload[8U] & 0x01) << 5) + ((payload[9U] & 0xF4) >> 3));
 			LogDebug("UTC Second %d", (payload[9U] & 0x03)* 10);
 
-		    LogDebug("Result is %02d %02d.%d%s, %d %d.%d%s ", latDeg, latMin, latSec,latSign,
+			LogDebug("Result is %02d %02d.%d%s, %d %d.%d%s ", latDeg, latMin, latSec,latSign,
 		    							                      lonDeg, lonMin, lonSec,lonSign);
 
 			return true;

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -407,6 +407,51 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			}
 
 			return true;
+		} else if (dataType == DT_RATE_12_DATA) {
+			if (m_rfState == RS_RF_DATA)
+				return true;
+			LogMessage("DT_RATE_12_DATA Packet received");
+			
+			char latSign[2];
+			char lonSign[2];
+			CBPTC19696 bptc;
+			
+			unsigned char payload[12U];
+			bptc.decode(data + 2U, payload);
+			
+			CUtils::dump(1U, "Data Dump", payload, 12U);
+	
+			if ((payload[0U] & 0x40U) >> 6)
+				strcpy(latSign,"N");
+			else
+				strcpy(latSign,"S");
+
+			if ((payload[0U] & 0x20U) >> 5)
+				strcpy(lonSign,"E");
+			else
+				strcpy(lonSign,"W");
+			
+			if ((payload[0U] & 0x10U) >> 4)
+			 	LogDebug("GPS Fix");
+			else
+				LogDebug("NoGPS Fix");
+
+
+			uint8_t latDeg = ((payload[1U] & 0x1F) << 2) + ((payload[2U] & 0xC0) >> 6);
+		    uint8_t latMin = payload[2U] & 0x6F;
+		    int32_t latSec = (payload[3U] << 6) + (payload[4U] & 0xFC);
+		    uint8_t lonDeg = ((payload[4U] & 0x03) << 6) + ((payload[5U] & 0xFC) >> 2);
+		    uint8_t lonMin = ((payload[5U] & 0x03) << 4) + ((payload[6U] & 0xF0) >> 4);
+		    uint32_t lonSec = ((payload[6U] & 0x0F) << 8) + (payload[7U] << 2) + ((payload[8U] & 0xA0) >>6);
+		    
+		    LogDebug("UTC Hour %d", (payload[8U] & 0x3E) >> 1);
+			LogDebug("UTC Minute %d", ((payload[8U] & 0x01) << 5) + ((payload[9U] & 0xF4) >> 3));
+			LogDebug("UTC Second %d", (payload[9U] & 0x03)* 10);
+
+		    LogDebug("Result is %02d %02d.%d%s, %d %d.%d%s ", latDeg, latMin, latSec,latSign,
+		    							                      lonDeg, lonMin, lonSec,lonSign);
+
+			return true;
 		} else if (dataType == DT_CSBK) {
 			CDMRCSBK csbk;
 			bool valid = csbk.put(data + 2U);

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -419,7 +419,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			LogMessage("DT_RATE_12_DATA Packet received");
 			
 			bool gi = dataHeader.getGI();
-			unsigned int srcId = GPSsrcId; // Grabs the Global value... FixMe
+			unsigned int srcId = 272999;
 			unsigned int dstId = 272999;   // APRS Destination for Ireland
 			LogDebug("src: %d, dst: %d", srcId, dstId);
 			if (!CDMRAccessControl::validateSrcId(srcId)) {
@@ -473,8 +473,10 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			 	LogDebug("Position: %02d %02d.%03d%s, %03d %02d.%03d%s at Alt of %dm",	latDeg, latMin, latSec,latSign,
 										                      							lonDeg, lonMin, lonSec, lonSign, alt);
 				
+				
 				// Winging it completely! All I can say is it doesn't crash! 
 				// Does BM even accept this type of data frame?
+				
 				bptc.encode(payload, data + 2U);
 				CDMRSlotType slotType;
 				slotType.putData(data + 2U);
@@ -486,7 +488,9 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 
 				data[1U] = 0x00U;
 
+
 				writeNetworkRF(data, dataType);
+				CUtils::dump(1U, "Data Dump", data, 12U);
 			}
 			else
 				LogDebug("No GPS Fix");

--- a/Modem.cpp
+++ b/Modem.cpp
@@ -916,7 +916,7 @@ bool CModem::readVersion()
 			}
 		}
 
-		CThread::sleep(1000U);
+		CThread::sleep(1500U);
 	}
 
 	LogError("Unable to read the firmware version after six attempts");


### PR DESCRIPTION
Evening,
I've been experimenting with this the last while.  It is currently working with my fork of DMRGateway (https://github.com/jpronans/DMRGateway)

In summary
* The RT8 generates a UDT/NMEA frame, followed by a DT_RATE_12_DATA frame
* The DT_RATE_12_DATA frame has no source/destination address.
I have quite simply just saved off the Source and Destination addresses from the UDT/NMEA frame and re-used them in the following frame.  

Issues I can think of:
* Use of global variables.
* If the UDT/NMEA DT_DATA_HEADER frame is missed, then obviously the GPS position gets lost
* If the DT_RATE_12_DATA frame with the GPS positions in it get missed, plus the next NMEA_DATA_HEADER frame, then the GPS position will get sent with the wrong source address.

Regards
John
EI7IG


This is really more to get a discussion going about the correct way to approach it as i'm in no way a software developer.
