### PR TITLE
Data was taken with F0DEI PCB v1.2 instead of ZUM v1.0

### DIFF
--- a/RSSI/RSSI_GM1200E_DEIv1.2.dat
+++ b/RSSI/RSSI_GM1200E_DEIv1.2.dat
@@ -5,6 +5,7 @@
 # Raw RSSI Value		dBm Value
 #
 # provided by Wilm DL4OCH
+# Data taken with F0DEI MMDVM v1.2 and 47k/27k divider in RSSI input
 
 2263		-43
 2235		-53


### PR DESCRIPTION
Sorry, I mis-named the RSSI.dat from the previous commit :-(