### PR TITLE
Idle Screen for OLED display is now a Screensaver

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -160,7 +160,7 @@ void COLED::setIdleInt()
 //    display.print("Idle");
 
 //    display.setTextSize(1);
-    display.startscrolldiagright(0x00,0x0f);  //the log scrolls the whole screen
+    display.startscrolldiagright(0x00,0x0f);  //the MMDVM logo scrolls the whole screen
     display.display();
 }
 

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -155,12 +155,12 @@ void COLED::setIdleInt()
     display.clearDisplay();
     OLED_statusbar();
 
-    display.setCursor(0,30);
-    display.setTextSize(3);
-    display.print("Idle");
+//    display.setCursor(0,30);
+//    display.setTextSize(3);
+//    display.print("Idle");
 
-    display.setTextSize(1);
-    display.startscrollleft(0x02,0x0f);
+//    display.setTextSize(1);
+    display.startscrolldiagright(0x00,0x0f);  //the log scrolls the whole screen
     display.display();
 }
 


### PR DESCRIPTION
No text. Only the MMDVM logo scrolling through the whole screen as a screensaver for the Idle page.