### PR TITLE
Account for 8/9 digit DMR IDs in P25 SelfOnly access control.

### DIFF
--- a/P25Control.cpp
+++ b/P25Control.cpp
@@ -188,7 +188,23 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 			unsigned int srcId = m_rfData.getSrcId();
 
 			if (m_selfOnly) {
-				if (srcId != m_id) {
+				if (m_id > 99999999U) {		// Check that the Config DMR-ID is bigger than 8 digits
+					if (srcId != m_id / 100U) {
+						LogMessage("P25, invalid access attempt from %u", srcId);
+						m_rfState = RS_RF_REJECTED;
+						return false;
+					}
+				}
+
+				else if (m_id > 9999999U) {	// Check that the Config DMR-ID is bigger than 7 digits
+					if (srcId != m_id / 10U) {
+						LogMessage("P25, invalid access attempt from %u", srcId);
+						m_rfState = RS_RF_REJECTED;
+						return false;
+					}
+				}
+
+				else if (srcId != m_id) {	// All other cases
 					LogMessage("P25, invalid access attempt from %u", srcId);
 					m_rfState = RS_RF_REJECTED;
 					return false;


### PR DESCRIPTION
Many hotspot users have 8/9 digit DMR IDs configured, the 7 Digit ID in the radio will then fail the match.
This is a possibly ugly but functional patch that will account for those cases (similar to the recent work on the DMR Access for the same reasons).

Andy (MW0MWZ)