### PR TITLE
 Rename config file values (acc. to #ee93e4ce)

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -157,8 +157,8 @@ m_dmrNetworkModeHang(3U),
 m_fusionNetworkEnabled(false),
 m_fusionNetworkMyAddress(),
 m_fusionNetworkMyPort(0U),
-m_fusionNetworkGwyAddress(),
-m_fusionNetworkGwyPort(0U),
+m_fusionNetworkGatewayAddress(),
+m_fusionNetworkGatewayPort(0U),
 m_fusionNetworkModeHang(3U),
 m_fusionNetworkDebug(false),
 m_p25NetworkEnabled(false),
@@ -548,10 +548,10 @@ bool CConf::read()
 			m_fusionNetworkMyAddress = value;
 		else if (::strcmp(key, "LocalPort") == 0)
 			m_fusionNetworkMyPort = (unsigned int)::atoi(value);
-		else if (::strcmp(key, "GwyAddress") == 0)
-			m_fusionNetworkGwyAddress = value;
-		else if (::strcmp(key, "GwyPort") == 0)
-			m_fusionNetworkGwyPort = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "GatewayAddress") == 0)
+			m_fusionNetworkGatewayAddress = value;
+		else if (::strcmp(key, "GatewayPort") == 0)
+			m_fusionNetworkGatewayPort = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "ModeHang") == 0)
 			m_fusionNetworkModeHang = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "Debug") == 0)
@@ -1157,14 +1157,14 @@ unsigned int CConf::getFusionNetworkMyPort() const
 	return m_fusionNetworkMyPort;
 }
 
-std::string CConf::getFusionNetworkGwyAddress() const
+std::string CConf::getFusionNetworkGatewayAddress() const
 {
-	return m_fusionNetworkGwyAddress;
+	return m_fusionNetworkGatewayAddress;
 }
 
-unsigned int CConf::getFusionNetworkGwyPort() const
+unsigned int CConf::getFusionNetworkGatewayPort() const
 {
-	return m_fusionNetworkGwyPort;
+	return m_fusionNetworkGatewayPort;
 }
 
 unsigned int CConf::getFusionNetworkModeHang() const

--- a/Conf.h
+++ b/Conf.h
@@ -160,8 +160,8 @@ public:
   bool         getFusionNetworkEnabled() const;
   std::string  getFusionNetworkMyAddress() const;
   unsigned int getFusionNetworkMyPort() const;
-  std::string  getFusionNetworkGwyAddress() const;
-  unsigned int getFusionNetworkGwyPort() const;
+  std::string  getFusionNetworkGatewayAddress() const;
+  unsigned int getFusionNetworkGatewayPort() const;
   unsigned int getFusionNetworkModeHang() const;
   bool         getFusionNetworkDebug() const;
 
@@ -328,8 +328,8 @@ private:
   bool         m_fusionNetworkEnabled;
   std::string  m_fusionNetworkMyAddress;
   unsigned int m_fusionNetworkMyPort;
-  std::string  m_fusionNetworkGwyAddress;
-  unsigned int m_fusionNetworkGwyPort;
+  std::string  m_fusionNetworkGatewayAddress;
+  unsigned int m_fusionNetworkGatewayPort;
   unsigned int m_fusionNetworkModeHang;
   bool         m_fusionNetworkDebug;
 

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -129,8 +129,8 @@ Debug=0
 Enable=1
 LocalAddress=127.0.0.1
 LocalPort=3200
-GwyAddress=127.0.0.1
-GwyPort=4200
+GatewayAddress=127.0.0.1
+GatewayPort=4200
 # ModeHang=3
 Debug=0
 

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -995,19 +995,19 @@ bool CMMDVMHost::createYSFNetwork()
 {
 	std::string myAddress  = m_conf.getFusionNetworkMyAddress();
 	unsigned int myPort    = m_conf.getFusionNetworkMyPort();
-	std::string gwyAddress = m_conf.getFusionNetworkGwyAddress();
-	unsigned int gwyPort   = m_conf.getFusionNetworkGwyPort();
+	std::string gatewayAddress = m_conf.getFusionNetworkGatewayAddress();
+	unsigned int gatewayPort   = m_conf.getFusionNetworkGatewayPort();
 	m_ysfNetModeHang       = m_conf.getFusionNetworkModeHang();
 	bool debug             = m_conf.getFusionNetworkDebug();
 
 	LogInfo("System Fusion Network Parameters");
 	LogInfo("    Local Address: %s", myAddress.c_str());
 	LogInfo("    Local Port: %u", myPort);
-	LogInfo("    Gateway Address: %s", gwyAddress.c_str());
-	LogInfo("    Gateway Port: %u", gwyPort);
+	LogInfo("    Gateway Address: %s", gatewayAddress.c_str());
+	LogInfo("    Gateway Port: %u", gatewayPort);
 	LogInfo("    Mode Hang: %us", m_ysfNetModeHang);
 
-	m_ysfNetwork = new CYSFNetwork(myAddress, myPort, gwyAddress, gwyPort, m_callsign, debug);
+	m_ysfNetwork = new CYSFNetwork(myAddress, myPort, gatewayAddress, gatewayPort, m_callsign, debug);
 
 	bool ret = m_ysfNetwork->open();
 	if (!ret) {

--- a/YSFNetwork.cpp
+++ b/YSFNetwork.cpp
@@ -28,10 +28,10 @@
 
 const unsigned int BUFFER_LENGTH = 200U;
 
-CYSFNetwork::CYSFNetwork(const std::string& myAddress, unsigned int myPort, const std::string& gwyAddress, unsigned int gwyPort, const std::string& callsign, bool debug) :
+CYSFNetwork::CYSFNetwork(const std::string& myAddress, unsigned int myPort, const std::string& gatewayAddress, unsigned int gatewayPort, const std::string& callsign, bool debug) :
 m_socket(myAddress, myPort),
 m_address(),
-m_port(gwyPort),
+m_port(gatewayPort),
 m_callsign(),
 m_debug(debug),
 m_enabled(false),
@@ -42,7 +42,7 @@ m_tag(NULL)
 	m_callsign = callsign;
 	m_callsign.resize(YSF_CALLSIGN_LENGTH, ' ');
 
-	m_address = CUDPSocket::lookup(gwyAddress);
+	m_address = CUDPSocket::lookup(gatewayAddress);
 
 	m_tag = new unsigned char[YSF_CALLSIGN_LENGTH];
 	::memset(m_tag, ' ', YSF_CALLSIGN_LENGTH);

--- a/YSFNetwork.h
+++ b/YSFNetwork.h
@@ -29,7 +29,7 @@
 
 class CYSFNetwork {
 public:
-	CYSFNetwork(const std::string& myAddress, unsigned int myPort, const std::string& gwyAddress, unsigned int gwyPort, const std::string& callsign, bool debug);
+	CYSFNetwork(const std::string& myAddress, unsigned int myPort, const std::string& gatewayAddress, unsigned int gatewayPort, const std::string& callsign, bool debug);
 	~CYSFNetwork();
 
 	bool open();


### PR DESCRIPTION
Standardize variable names in MMDVM.ini

![photo_2017-11-09_23-19-04](https://user-images.githubusercontent.com/7112907/32632571-68f7275c-c5a4-11e7-928a-8ee7ddefedcd.jpg)
