### PR TITLE
fix: ArduiPi_OLED wants -li2c

### DIFF
--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -3,7 +3,7 @@
 CC      = gcc
 CXX     = g++
 CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -DOLED -I/usr/local/include
-LIBS    = -lArduiPi_OLED -lpthread
+LIBS    = -lArduiPi_OLED -li2c -lpthread
 LDFLAGS = -g -L/usr/local/lib
 
 OBJECTS = \


### PR DESCRIPTION
```
/usr/local/lib/libArduiPi_OLED.so: undefined reference to `i2c_smbus_write_i2c_block_data'
/usr/local/lib/libArduiPi_OLED.so: undefined reference to `i2c_smbus_write_word_data'
/usr/local/lib/libArduiPi_OLED.so: undefined reference to `i2c_smbus_write_byte_data'
collect2: error: ld returned 1 exit status
```
^^ as title says. 