### PR TITLE
Bad Nextion RSSI values

### DIFF
--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -353,7 +353,7 @@ void CNextion::writeDMRRSSIInt(unsigned int slotNo, unsigned char rssi)
     
 		if (m_rssiCount1 == DMR_RSSI_COUNT) {
 			char text[20U];
-			::sprintf(text, "t4.txt=\"-%udBm\"", m_rssiAccum1 / DMR_RSSI_COUNT);
+			::sprintf(text, "t4.txt=\"-%udBm\"", m_rssiAccum1 / (DMR_RSSI_COUNT-1));
 			sendCommand(text);
 			sendCommandAction(66U);
 			m_rssiAccum1 = 0U;
@@ -374,7 +374,7 @@ void CNextion::writeDMRRSSIInt(unsigned int slotNo, unsigned char rssi)
 
 		if (m_rssiCount2 == DMR_RSSI_COUNT) {
 			char text[20U];
-			::sprintf(text, "t5.txt=\"-%udBm\"", m_rssiAccum2 / DMR_RSSI_COUNT);
+			::sprintf(text, "t5.txt=\"-%udBm\"", m_rssiAccum2 / (DMR_RSSI_COUNT-1));
 			sendCommand(text);
 			sendCommandAction(74U);
 			m_rssiAccum2 = 0U;


### PR DESCRIPTION
My interpretation of the nextion.ccp source is that following a first display of rssi variable (m_rssiCount1 =0), after 4 counts of m_rssiCount1 the average value is displayed (m_rssiAccum1/DMR_RSSI_COUNT). Now it seems that this averaged value is wrongly calculated as it is always 3/4 of the real rssi value, as it was calculated cumulating just 3 rssi consecutive values and not 4. The same applies to slot 2 calculations, and maybe a similar mistake is in the ber calculation ( though not as much as evident because it is diluted in a larger number of samples), applying my fixes divide by 3 instead 4 the values displayed in the Nextion, now is correct !
I modified only DMR side , I think it is only a workaround.
73 de IW9GRL