### PR TITLE
Adding a modem port template

### DIFF
--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -38,6 +38,7 @@ Time=24
 
 [Modem]
 # Port=/dev/ttyACM0
+# Port=/dev/ttyAMA0
 Port=\\.\COM3
 TXInvert=1
 RXInvert=0


### PR DESCRIPTION
Adding the line # Port=/dev/ttyAMA0 to MMDVM.ini [Modem] section, to make it easier to try out the correct port setting fore the more and more commonly used STM32 Pi hat boards.