### PR TITLE
Correct path for the nightly snapshot of the DMR Id database

### DIFF
--- a/DMRIDUpdate.sh
+++ b/DMRIDUpdate.sh
@@ -90,7 +90,7 @@ then
 fi
 
 # Generate new file
-curl 'http://www.dmr-marc.net/cgi-bin/trbo-database/datadump.cgi?table=users&format=csv&header=0' 2>/dev/null | awk -F"," '{printf "%s\t%s\t%s\n", $1, $2, $4 == "" ? $3 : $4}' | sed -e 's/\(.\) .*/\1/g' > ${DMRIDFILE}
+curl 'https://www.dmr-marc.net/static/users.csv' 2>/dev/null | awk -F"," '{printf "%s\t%s\t%s\n", $1, $2, $4 == "" ? $3 : $4}' | sed -e 's/\(.\) .*/\1/g' > ${DMRIDFILE}
 
 # Restart MMDVMHost
 eval ${RESTARTCOMMAND}


### PR DESCRIPTION
dmr-marc.net has discontinued access to the real time database feed for the DMR Id database. Users must download the nightly snapshot instead. 

The dmr-marc.net page offers some links here: http://dmr-marc.net/cgi-bin/trbo-database/ but there is a certificate error. The correct links must begin with "www".

So, the right link to download the ID database is https://www.dmr-marc.net/static/users.csv