### PR TITLE
Fix SSL errors

### DIFF
--- a/linux/DMRIDUpdate.sh
+++ b/linux/DMRIDUpdate.sh
@@ -52,8 +52,8 @@
 DMRIDPATH=/path/to/DMR/ID/file
 DMRIDFILE=${DMRIDPATH}/DMRIds.dat
 
-# DMR-MARC.net has discontinued real time access. Now they offer a nightly dump instead.
-DATABASEURL='https://radioid.net/static/users.csv'
+# DMR IDs now served by RadioID.net
+DATABASEURL='https://www.radioid.net/static/users.csv'
 
 #
 # How many DMR ID files do you want backed up (0 = do not keep backups)
@@ -95,7 +95,7 @@ then
 fi
 
 # Generate new file
-curl -k ${DATABASEURL} 2>/dev/null | sed -e 's/\t//g' | awk -F"," '/,/{gsub(/ /, "", $2); printf "%s\t%s\t%s\n", $1, $2, $3}' | sed -e 's/\(.\) .*/\1/g' > ${DMRIDPATH}/DMRIds.tmp
+curl ${DATABASEURL} 2>/dev/null | sed -e 's/\t//g' | awk -F"," '/,/{gsub(/ /, "", $2); printf "%s\t%s\t%s\n", $1, $2, $3}' | sed -e 's/\(.\) .*/\1/g' > ${DMRIDPATH}/DMRIds.tmp
 NUMOFLINES=$(wc -l ${DMRIDPATH}/DMRIds.tmp | awk '{print $1}')
 if [ $NUMOFLINES -gt 1 ]
 then


### PR DESCRIPTION
Fix curl's errors with invalid SSL certificate due to missing "www." in server name. Should also make the "-k" switch to curl obsolete.