### PR TITLE
Supports local time in log entries

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -77,6 +77,7 @@ m_logDisplayLevel(0U),
 m_logFileLevel(0U),
 m_logFilePath(),
 m_logFileRoot(),
+m_logUTC(true),
 m_cwIdEnabled(false),
 m_cwIdTime(10U),
 m_cwIdCallsign(),
@@ -365,6 +366,8 @@ bool CConf::read()
 			m_logFileLevel = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "DisplayLevel") == 0)
 			m_logDisplayLevel = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "UTC") == 0)
+			m_logUTC = ::atoi(value) != 0;
 	} else if (section == SECTION_CWID) {
 		if (::strcmp(key, "Enable") == 0)
 			m_cwIdEnabled = ::atoi(value) == 1;
@@ -833,6 +836,11 @@ std::string CConf::getLogFilePath() const
 std::string CConf::getLogFileRoot() const
 {
 	return m_logFileRoot;
+}
+
+bool CConf::getLogUTC() const
+{
+	return m_logUTC;
 }
 
 bool CConf::getCWIdEnabled() const

--- a/Conf.h
+++ b/Conf.h
@@ -54,6 +54,7 @@ public:
   unsigned int getLogFileLevel() const;
   std::string  getLogFilePath() const;
   std::string  getLogFileRoot() const;
+  bool         getLogUTC() const;
 
   // The CW ID section
   bool         getCWIdEnabled() const;
@@ -266,6 +267,7 @@ private:
   unsigned int m_logFileLevel;
   std::string  m_logFilePath;
   std::string  m_logFileRoot;
+  bool         m_logUTC;
 
   bool         m_cwIdEnabled;
   unsigned int m_cwIdTime;

--- a/Log.cpp
+++ b/Log.cpp
@@ -43,6 +43,7 @@ static struct tm m_tm;
 
 static char LEVELS[] = " DMIWEF";
 
+static bool m_utc = true;
 static bool LogOpen()
 {
 	if (m_fileLevel == 0U)
@@ -51,7 +52,13 @@ static bool LogOpen()
 	time_t now;
 	::time(&now);
 
-	struct tm* tm = ::gmtime(&now);
+	struct tm* tm;
+	if(m_utc)
+	{
+		tm = ::gmtime(&now);
+	}else{
+		tm = ::localtime(&now);
+	}
 
 	if (tm->tm_mday == m_tm.tm_mday && tm->tm_mon == m_tm.tm_mon && tm->tm_year == m_tm.tm_year) {
 		if (m_fpLog != NULL)
@@ -74,12 +81,13 @@ static bool LogOpen()
     return m_fpLog != NULL;
 }
 
-bool LogInitialise(const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel)
+bool LogInitialise(const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, bool utc)
 {
 	m_filePath     = filePath;
 	m_fileRoot     = fileRoot;
 	m_fileLevel    = fileLevel;
 	m_displayLevel = displayLevel;
+	m_utc          = utc;
     return ::LogOpen();
 }
 
@@ -103,7 +111,14 @@ void Log(unsigned int level, const char* fmt, ...)
 	struct timeval now;
 	::gettimeofday(&now, NULL);
 
-	struct tm* tm = ::gmtime(&now.tv_sec);
+	struct tm* tm;
+	
+	if(m_utc)
+	{
+		tm = ::gmtime(&now.tv_sec);
+	}else{
+		tm = ::localtime(&now.tv_sec);
+	}
 
 	::sprintf(buffer, "%c: %04d-%02d-%02d %02d:%02d:%02d.%03lu ", LEVELS[level], tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, now.tv_usec / 1000U);
 #endif

--- a/Log.h
+++ b/Log.h
@@ -30,7 +30,7 @@
 
 extern void Log(unsigned int level, const char* fmt, ...);
 
-extern bool LogInitialise(const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel);
+extern bool LogInitialise(const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, bool utc);
 extern void LogFinalise();
 
 #endif

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -26,6 +26,7 @@ DisplayLevel=1
 FileLevel=1
 FilePath=.
 FileRoot=MMDVM
+# UTC=1  1:use UTC time or 0:use local time
 
 [CW Id]
 Enable=1

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -243,7 +243,7 @@ int CMMDVMHost::run()
 #endif
 #endif
 
-	ret = ::LogInitialise(m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel());
+	ret = ::LogInitialise(m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogUTC());
 	if (!ret) {
 		::fprintf(stderr, "MMDVMHost: unable to open the log file\n");
 		return 1;


### PR DESCRIPTION
Add the configure entry in Log section to print local timestamp in the log file.
If nothing is set, the default behavior will be the same as before, using UTC