### PR TITLE
Add forwarding of alphanum payload for func Alert2 msgs

### DIFF
--- a/POCSAGControl.cpp
+++ b/POCSAGControl.cpp
@@ -130,8 +130,9 @@ bool CPOCSAGControl::processData()
 			LogDebug("Message to %07u, func Alert 1", m_ric);
 			break;
 		case FUNCTIONAL_ALERT2:
-			m_text.clear();
-			LogDebug("Message to %07u, func Alert 2", m_ric);
+			m_text = std::string((char*)(data + 4U), length - 4U);
+			LogDebug("Message to %07u, func Alert 2: \"%s\"", m_ric, m_text.c_str());
+			packASCII();
 			break;
 		default:
 			break;


### PR DESCRIPTION
Fix to activate german Skyper pagers: Activation msg is of func "alert2" and contains an alphanumerical payload. Alert2 handling has been modified in a way to forward this alphanum payload rather than discarding it.
