### PR TITLE
Fix compile error:

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -578,7 +578,7 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CUMP* ump, CModem* modem)
 			if (displayClock)
 				LogInfo("    Display UTC: %s", utc ? "yes" : "no");
 
-			m_display = new CHD44780(rows, columns, conf.getCallsign(), dmrid, pins, i2cAddress, pwm, pwmPin, pwmBright, pwmDim, displayClock, utc, conf.getDuplex());
+			display = new CHD44780(rows, columns, conf.getCallsign(), dmrid, pins, i2cAddress, pwm, pwmPin, pwmBright, pwmDim, displayClock, utc, conf.getDuplex());
 		}
 #endif
 


### PR DESCRIPTION
Compile time error:

# make -f Makefile.Pi.PCF8574
g++ -g -O3 -Wall -std=c++0x -pthread -DHD44780 -DPCF8574_DISPLAY -I/usr/local/include -c -o Display.o Display.cpp
Display.cpp: In static member function ‘static CDisplay* CDisplay::createDisplay(const CConf&, CUMP*, CModem*)’:
Display.cpp:581:4: error: ‘m_display’ was not declared in this scope
    m_display = new CHD44780(rows, columns, conf.getCallsign(), dmrid, pins, i2cAddress, pwm, pwmPin, pwmBright, pwmDim, displayClock, utc, conf.getDuplex());
    ^
Makefile.Pi.PCF8574:24: recipe for target 'Display.o' failed
make: *** [Display.o] Error 1

looks like every other instance of "m_display" was changed to "display" apart from line 581.