### PR TITLE
Fix buffer overflow + better way to display that MMDVMHost quits

### DIFF
--- a/Defines.h
+++ b/Defines.h
@@ -29,6 +29,7 @@ const unsigned char MODE_POCSAG  = 6U;
 const unsigned char MODE_CW      = 98U;
 const unsigned char MODE_LOCKOUT = 99U;
 const unsigned char MODE_ERROR   = 100U;
+const unsigned char MODE_QUIT    = 110U;
 
 const unsigned char TAG_HEADER = 0x00U;
 const unsigned char TAG_DATA   = 0x01U;

--- a/Display.cpp
+++ b/Display.cpp
@@ -88,6 +88,17 @@ void CDisplay::setError(const char* text)
 	setErrorInt(text);
 }
 
+void CDisplay::setQuit()
+{
+	m_timer1.stop();
+	m_timer2.stop();
+
+	m_mode1 = MODE_QUIT;
+	m_mode2 = MODE_QUIT;
+
+	setQuitInt();
+}
+
 void CDisplay::writeDStar(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
 	assert(my1 != NULL);

--- a/Display.h
+++ b/Display.h
@@ -40,6 +40,7 @@ public:
 	void setIdle();
 	void setLockout();
 	void setError(const char* text);
+	void setQuit();
 
 	void writeDStar(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
 	void writeDStarRSSI(unsigned char rssi);
@@ -82,6 +83,7 @@ protected:
 	virtual void setIdleInt() = 0;
 	virtual void setLockoutInt() = 0;
 	virtual void setErrorInt(const char* text) = 0;
+	virtual void setQuitInt() = 0;
 
 	virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector) = 0;
 	virtual void writeDStarRSSIInt(unsigned char rssi);

--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -374,6 +374,31 @@ void CHD44780::setLockoutInt()
 	m_dmr = false;
 }
 
+void CHD44780::setQuitInt()
+{
+#ifdef ADAFRUIT_DISPLAY
+	adafruitLCDColour(AC_RED);
+#endif
+
+	m_clockDisplayTimer.stop();           // Stop the clock display
+	::lcdClear(m_fd);
+
+	if (m_pwm) {
+		if (m_pwmPin != 1U)
+			::softPwmWrite(m_pwmPin, m_pwmBright);
+		else
+			::pwmWrite(m_pwmPin, (m_pwmBright / 100) * 1024);
+	}
+
+	::lcdPosition(m_fd, 0, 0);
+	::lcdPuts(m_fd, "MMDVM");
+
+	::lcdPosition(m_fd, 0, 1);
+	::lcdPuts(m_fd, "STOPPED");
+
+	m_dmr = false;
+}
+
 void CHD44780::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
 	assert(my1 != NULL);

--- a/HD44780.h
+++ b/HD44780.h
@@ -100,6 +100,7 @@ protected:
   virtual void setIdleInt();
   virtual void setErrorInt(const char* text);
   virtual void setLockoutInt();
+  virtual void setQuitInt();
 
   virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
   virtual void writeDStarRSSIInt(unsigned char rssi); 

--- a/LCDproc.cpp
+++ b/LCDproc.cpp
@@ -224,6 +224,23 @@ void CLCDproc::setLockoutInt()
 
 // LED 4 Green 8 Red 128 Yellow 136
 
+void CLCDproc::setQuitInt()
+{
+	m_clockDisplayTimer.stop();           // Stop the clock display
+
+	if (m_screensDefined) {
+		socketPrintf(m_socketfd, "screen_set DStar -priority hidden");
+		socketPrintf(m_socketfd, "screen_set DMR -priority hidden");
+		socketPrintf(m_socketfd, "screen_set YSF -priority hidden");
+		socketPrintf(m_socketfd, "screen_set P25 -priority hidden");
+		socketPrintf(m_socketfd, "screen_set NXDN -priority hidden");
+		socketPrintf(m_socketfd, "widget_set Status Status %u %u Stopped", m_cols - 6, m_rows);
+		socketPrintf(m_socketfd, "output 0");   // Clear all LEDs
+	}
+
+	m_dmr = false;
+}
+
 void CLCDproc::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
 	assert(my1 != NULL);

--- a/LCDproc.h
+++ b/LCDproc.h
@@ -39,6 +39,8 @@ protected:
   virtual void setIdleInt();
   virtual void setErrorInt(const char* text);
   virtual void setLockoutInt();
+  virtual void setQuitInt();
+  
 
   virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
   virtual void writeDStarRSSIInt(unsigned char rssi);

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -971,7 +971,7 @@ int CMMDVMHost::run()
 			CThread::sleep(5U);
 	}
 
-	setMode(MODE_IDLE);
+	setMode(MODE_QUIT);
 
 	m_modem->close();
 	delete m_modem;
@@ -1560,6 +1560,9 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_cwIdTimer.start();
 		}
 		m_display->setIdle();
+		if (mode==MODE_QUIT) {
+			m_display->setQuit();
+		}
 		m_mode = MODE_IDLE;
 		m_modeTimer.stop();
 		break;

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -99,7 +99,7 @@ void CNextion::setIdleInt()
 	sendCommand("page MMDVM");
 	sendCommandAction(1U);
 
-	char command[30U];
+	char command[100U];
 	::sprintf(command, "dim=%u", m_idleBrightness);
 	sendCommand(command);
 	

--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -165,6 +165,27 @@ void CNextion::setLockoutInt()
 	m_mode = MODE_LOCKOUT;
 }
 
+void CNextion::setQuitInt()
+{
+	sendCommand("page MMDVM");
+	sendCommandAction(1U);
+
+	char command[100];
+	::sprintf(command, "dim=%u", m_idleBrightness);
+	sendCommand(command);
+
+	::sprintf(command, "t3.txt=\"%s\"", m_ipaddress.c_str());
+	sendCommand(command);
+	sendCommandAction(16U);
+
+	sendCommand("t0.txt=\"MMDVM STOPPED\"");
+	sendCommandAction(19U);
+
+	m_clockDisplayTimer.stop();
+
+	m_mode = MODE_QUIT;
+}
+
 void CNextion::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
 	assert(my1 != NULL);
@@ -750,10 +771,6 @@ void CNextion::clockInt(unsigned int ms)
 
 void CNextion::close()
 {
-	sendCommand("page MMDVM");
-	sendCommandAction(1U);
-	sendCommand("t1.txt=\"MMDVM STOPPED\"");
-	sendCommandAction(19U);
 	m_serial->close();
 	delete m_serial;
 }

--- a/Nextion.h
+++ b/Nextion.h
@@ -40,6 +40,7 @@ protected:
   virtual void setIdleInt();
   virtual void setErrorInt(const char* text);
   virtual void setLockoutInt();
+  virtual void setQuitInt();
 
   virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
   virtual void writeDStarRSSIInt(unsigned char rssi);

--- a/NullDisplay.cpp
+++ b/NullDisplay.cpp
@@ -56,6 +56,10 @@ void CNullDisplay::setLockoutInt()
 {
 }
 
+void CNullDisplay::setQuitInt()
+{
+}
+
 void CNullDisplay::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
 #if defined(RASPBERRY_PI)

--- a/NullDisplay.h
+++ b/NullDisplay.h
@@ -37,6 +37,7 @@ protected:
 	virtual void setIdleInt();
 	virtual void setErrorInt(const char* text);
 	virtual void setLockoutInt();
+	virtual void setQuitInt();
 
 	virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
 	virtual void clearDStarInt();

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -283,6 +283,21 @@ void COLED::setLockoutInt()
     display.display();
 }
 
+void COLED::setQuitInt()
+{
+    m_mode = MODE_QUIT;
+
+    display.clearDisplay();
+    OLED_statusbar();
+
+    display.setCursor(0,30);
+    display.setTextSize(3);
+    display.print("Stopped");
+
+    display.setTextSize(1);
+    display.display();
+}
+
 void COLED::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
     m_mode = MODE_DSTAR;

--- a/OLED.h
+++ b/OLED.h
@@ -49,6 +49,8 @@ public:
 
   virtual void setErrorInt(const char* text);
   virtual void setLockoutInt();
+  virtual void setQuitInt();
+  
 
   virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
   virtual void clearDStarInt();

--- a/TFTSerial.cpp
+++ b/TFTSerial.cpp
@@ -145,6 +145,22 @@ void CTFTSerial::setLockoutInt()
 	m_mode = MODE_LOCKOUT;
 }
 
+void CTFTSerial::setQuitInt()
+{
+	// Clear the screen
+	clearScreen();
+
+	setFontSize(FONT_LARGE);
+
+	// Draw MMDVM logo
+	displayBitmap(0U, 0U, "MMDVM_sm.bmp");
+
+	gotoPosPixel(20U, 60U);
+	displayText("STOPPED");
+
+	m_mode = MODE_QUIT;
+}
+
 void CTFTSerial::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
 	assert(my1 != NULL);

--- a/TFTSerial.h
+++ b/TFTSerial.h
@@ -39,6 +39,7 @@ protected:
 	virtual void setIdleInt();
 	virtual void setErrorInt(const char* text);
 	virtual void setLockoutInt();
+	virtual void setQuitInt();
 
 	virtual void writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
 	virtual void clearDStarInt();


### PR DESCRIPTION
Fix buffer overflow when writing ipaddress info that became too long to Nextion display
(i.e. when using Predictable Network Interface Names in linux)

Better way to send to display that MMDVMHost is quitting
Also reduces the chance of unclean exit as a result of an assert() because the connection is already closed.