### PR TITLE
Add Support for OLED Rotate

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -234,6 +234,7 @@ m_oledType(3U),
 m_oledBrightness(0U),
 m_oledInvert(false),
 m_oledScroll(false),
+m_oledRotate(false),
 m_lcdprocAddress(),
 m_lcdprocPort(0U),
 m_lcdprocLocalPort(0U),
@@ -776,6 +777,8 @@ bool CConf::read()
 			m_oledInvert = ::atoi(value) == 1;
 		else if (::strcmp(key, "Scroll") == 0)
 			m_oledScroll = ::atoi(value) == 1;
+		else if (::strcmp(key, "Rotate") == 0)
+			m_oledRotate = ::atoi(value) == 1;
 	} else if (section == SECTION_LCDPROC) {
 		if (::strcmp(key, "Address") == 0)
 			m_lcdprocAddress = value;
@@ -1665,6 +1668,11 @@ bool CConf::getOLEDInvert() const
 bool CConf::getOLEDScroll() const
 {
 	return m_oledScroll;
+}
+
+bool CConf::getOLEDRotate() const
+{
+	return m_oledRotate;
 }
 
 std::string CConf::getLCDprocAddress() const

--- a/Conf.h
+++ b/Conf.h
@@ -253,6 +253,7 @@ public:
   unsigned char  getOLEDBrightness() const;
   bool           getOLEDInvert() const;
   bool           getOLEDScroll() const;
+  bool           getOLEDRotate() const;
 
   // The LCDproc section
   std::string  getLCDprocAddress() const;
@@ -467,6 +468,7 @@ private:
   unsigned char m_oledBrightness;
   bool          m_oledInvert;
   bool          m_oledScroll;
+  bool          m_oledRotate;
 
   std::string  m_lcdprocAddress;
   unsigned int m_lcdprocPort;

--- a/Display.cpp
+++ b/Display.cpp
@@ -608,7 +608,8 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CUMP* ump, CModem* modem)
         unsigned char brightness = conf.getOLEDBrightness();
         bool          invert     = conf.getOLEDInvert();
 		bool          scroll     = conf.getOLEDScroll();
-		display = new COLED(type, brightness, invert, scroll, conf.getDMRNetworkSlot1(), conf.getDMRNetworkSlot2());
+	bool          rotate     = conf.getOLEDRotate();
+		display = new COLED(type, brightness, invert, scroll, rotate, conf.getDMRNetworkSlot1(), conf.getDMRNetworkSlot2());
 #endif
 	} else {
 		LogWarning("No valid display found, disabling");

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -232,6 +232,7 @@ Type=3
 Brightness=0
 Invert=0
 Scroll=1
+Rotate=0
 
 [LCDproc]
 Address=localhost

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -169,11 +169,12 @@ const unsigned char logo_POCSAG_bmp [] =
 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 };
 
-COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert, bool displayScroll, bool slot1Enabled, bool slot2Enabled) :
+COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert, bool displayScroll, bool displayRotate, bool slot1Enabled, bool slot2Enabled) :
 m_displayType(displayType),
 m_displayBrightness(displayBrightness),
 m_displayInvert(displayInvert),
 m_displayScroll(displayScroll),
+m_displayRotate(displayRotate),
 m_slot1Enabled(slot1Enabled),
 m_slot2Enabled(slot2Enabled)
 {
@@ -206,6 +207,11 @@ bool COLED::open()
     display.invertDisplay(m_displayInvert ? 1 : 0);
     if (m_displayBrightness > 0U)
         display.setBrightness(m_displayBrightness);
+
+    if (m_displayRotate > 0U) {
+      display.sendCommand(0xC0);
+      display.sendCommand(0xA0);
+    }
 
     // init done
     display.clearDisplay();   // clears the screen  buffer

--- a/OLED.h
+++ b/OLED.h
@@ -40,7 +40,7 @@
 class COLED : public CDisplay 
 {
 public:
-  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert, bool displayScroll, bool slot1Enabled, bool slot2Enabled);
+  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert, bool displayScroll, bool displayRotate, bool slot1Enabled, bool slot2Enabled);
   virtual ~COLED();
 
   virtual bool open();
@@ -83,6 +83,7 @@ private:
   unsigned char m_displayBrightness;
   bool          m_displayInvert;
   bool          m_displayScroll;
+  bool          m_displayRotate;
   bool			m_slot1Enabled;
   bool			m_slot2Enabled;
   std::string   m_ipaddress;


### PR DESCRIPTION
This change adds support for a Rotate=0|1 option in OLED MMDVM.ini (with default being 0) that will rotate the OLED 180 degrees.  This has been requested by folks who wish to have their hotspot screens facing them with the USB cable facing up.