### PR TITLE
Experimental P25 changes for LDU LC drop

### DIFF
--- a/P25Control.cpp
+++ b/P25Control.cpp
@@ -126,7 +126,7 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 		else
 			LogMessage("P25, transmission lost, %.1f seconds, BER: %.1f%%", float(m_rfFrames) / 5.56F, float(m_rfErrs * 100U) / float(m_rfBits));
 
-        LogMessage("P25, total frames: %d, bits: %d, undecodable LC: %d, errors: %d, BER: %.4f%%", m_rfFrames, m_rfBits, m_rfUndecodableLC, m_rfErrs, float(m_rfErrs * 100U) / float(m_rfBits));
+		LogMessage("P25, total frames: %d, bits: %d, undecodable LC: %d, errors: %d, BER: %.4f%%", m_rfFrames, m_rfBits, m_rfUndecodableLC, m_rfErrs, float(m_rfErrs * 100U) / float(m_rfBits));
 
 		if (m_netState == RS_NET_IDLE)
 			m_display->clearP25();
@@ -213,23 +213,23 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 		m_rssiCount++;
 	}
 
-    if (duid == P25_DUID_HEADER) {
-        if (m_rfState == RS_RF_LISTENING) {
-            m_rfData.reset();
-            bool ret = m_rfData.decodeHeader(data + 2U);
-            if (!ret) {
-                m_lastDUID = duid;
-                return false;
-            }
+	if (duid == P25_DUID_HEADER) {
+		if (m_rfState == RS_RF_LISTENING) {
+			m_rfData.reset();
+			bool ret = m_rfData.decodeHeader(data + 2U);
+			if (!ret) {
+				m_lastDUID = duid;
+				return false;
+			}
 
-            LogMessage("P25, received RF header");
+			LogMessage("P25, received RF header");
 
-            m_lastDUID = duid;
-            return true;
-        }
-    }
-    else if (duid == P25_DUID_LDU1) {
-        if (m_rfState == RS_RF_LISTENING) {
+			m_lastDUID = duid;
+			return true;
+		}
+	}
+	else if (duid == P25_DUID_LDU1) {
+		if (m_rfState == RS_RF_LISTENING) {
 			m_rfData.reset();
 			bool ret = m_rfData.decodeLDU1(data + 2U);
 			if (!ret) {
@@ -283,14 +283,14 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 
 		if (m_rfState == RS_RF_AUDIO) {
 			bool ret = m_rfData.decodeLDU1(data + 2U);
-            if (!ret) {
-                LogWarning("P25, LDU1 undecodable LC, using last LDU1 LC");
-                m_rfData = m_rfLastLDU1;
-                m_rfUndecodableLC++;
-            }
-            else {
-                m_rfLastLDU1 = m_rfData;
-            }
+			if (!ret) {
+				LogWarning("P25, LDU1 undecodable LC, using last LDU1 LC");
+				m_rfData = m_rfLastLDU1;
+				m_rfUndecodableLC++;
+			}
+			else {
+				m_rfLastLDU1 = m_rfData;
+			}
 
 			// Regenerate Sync
 			CSync::addP25Sync(data + 2U);
@@ -337,14 +337,14 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 	} else if (duid == P25_DUID_LDU2) {
 		if (m_rfState == RS_RF_AUDIO) {
 			bool ret = m_rfData.decodeLDU2(data + 2U);
-            if (!ret) {
-                LogWarning("P25, LDU2 undecodable LC, using last LDU2 LC");
-                m_rfData = m_rfLastLDU2;
-                m_rfUndecodableLC++;
-            }
-            else {
-                m_rfLastLDU2 = m_rfData;
-            }
+			if (!ret) {
+				LogWarning("P25, LDU2 undecodable LC, using last LDU2 LC");
+				m_rfData = m_rfLastLDU2;
+				m_rfUndecodableLC++;
+			}
+			else {
+				m_rfLastLDU2 = m_rfData;
+			}
 
 			writeNetwork(m_rfLDU, m_lastDUID, false);
 
@@ -494,7 +494,7 @@ bool CP25Control::writeModem(unsigned char* data, unsigned int len)
 			else
 				LogMessage("P25, received RF end of voice transmission, %.1f seconds, BER: %.1f%%", float(m_rfFrames) / 5.56F, float(m_rfErrs * 100U) / float(m_rfBits));
 
-            LogMessage("P25, total frames: %d, bits: %d, undecodable LC: %d, errors: %d, BER: %.4f%%", m_rfFrames, m_rfBits, m_rfUndecodableLC, m_rfErrs, float(m_rfErrs * 100U) / float(m_rfBits));
+			LogMessage("P25, total frames: %d, bits: %d, undecodable LC: %d, errors: %d, BER: %.4f%%", m_rfFrames, m_rfBits, m_rfUndecodableLC, m_rfErrs, float(m_rfErrs * 100U) / float(m_rfBits));
 
 			m_display->clearP25();
 
@@ -953,9 +953,9 @@ void CP25Control::createRFHeader()
 
 	m_rfFrames = 0U;
 	m_rfErrs = 0U;
-    m_rfUndecodableLC = 0U;
-    m_rfLastLDU1.reset();
-    m_rfLastLDU2.reset();
+	m_rfUndecodableLC = 0U;
+	m_rfLastLDU1.reset();
+	m_rfLastLDU2.reset();
 	m_rfBits = 1U;
 	m_rfTimeout.start();
 	m_lastDUID = P25_DUID_HEADER;

--- a/P25Control.h
+++ b/P25Control.h
@@ -65,6 +65,7 @@ private:
 	unsigned int               m_rfFrames;
 	unsigned int               m_rfBits;
 	unsigned int               m_rfErrs;
+    unsigned int               m_rfUndecodableLC;
 	unsigned int               m_netFrames;
 	unsigned int               m_netLost;
 	unsigned int               m_rfDataFrames;
@@ -72,7 +73,9 @@ private:
 	unsigned char              m_lastDUID;
 	CP25Audio                  m_audio;
 	CP25Data                   m_rfData;
-	CP25Data                   m_netData;
+    CP25Data                   m_rfLastLDU1;
+    CP25Data                   m_rfLastLDU2;
+    CP25Data                   m_netData;
 	CP25LowSpeedData           m_rfLSD;
 	CP25LowSpeedData           m_netLSD;
 	unsigned char*             m_netLDU1;

--- a/P25Control.h
+++ b/P25Control.h
@@ -65,7 +65,7 @@ private:
 	unsigned int               m_rfFrames;
 	unsigned int               m_rfBits;
 	unsigned int               m_rfErrs;
-    unsigned int               m_rfUndecodableLC;
+	unsigned int               m_rfUndecodableLC;
 	unsigned int               m_netFrames;
 	unsigned int               m_netLost;
 	unsigned int               m_rfDataFrames;
@@ -73,9 +73,9 @@ private:
 	unsigned char              m_lastDUID;
 	CP25Audio                  m_audio;
 	CP25Data                   m_rfData;
-    CP25Data                   m_rfLastLDU1;
-    CP25Data                   m_rfLastLDU2;
-    CP25Data                   m_netData;
+	CP25Data                   m_rfLastLDU1;
+	CP25Data                   m_rfLastLDU2;
+	CP25Data                   m_netData;
 	CP25LowSpeedData           m_rfLSD;
 	CP25LowSpeedData           m_netLSD;
 	unsigned char*             m_netLDU1;

--- a/P25Data.cpp
+++ b/P25Data.cpp
@@ -55,6 +55,25 @@ CP25Data::~CP25Data()
 	delete[] m_mi;
 }
 
+CP25Data& CP25Data::operator=(const CP25Data& data)
+{
+	if (this != &data) {
+		m_mfId = data.m_mfId;
+
+		m_srcId = data.m_srcId;
+		m_dstId = data.m_dstId;
+
+		m_emergency = data.m_emergency;
+
+		m_algId = data.m_algId;
+		m_kId = data.m_kId;
+
+		::memcpy(m_mi, data.m_mi, P25_MI_LENGTH_BYTES);
+	}
+
+	return *this;
+}
+
 bool CP25Data::decodeHeader(const unsigned char* data)
 {
 	assert(data != NULL);

--- a/P25Data.h
+++ b/P25Data.h
@@ -27,6 +27,8 @@ class CP25Data {
 public:
 	CP25Data();
 	~CP25Data();
+	
+	CP25Data& operator=(const CP25Data& data);
 
 	bool decodeHeader(const unsigned char* data);
 	void encodeHeader(unsigned char* data);


### PR DESCRIPTION
These are some experimental changes for the choppy P25 audio issue reported by @AndyTaylorTweet. I suspect the P25 audio is choppy because of a poor logic check causing the entire LDU frame to be dropped when the LDU LC data failed to decode properly.

In this PR, I've implemented some logic to store the last decoded LDU1 or LDU2 LC data, and in the case of a undecodable LC, use that last stored LC. This should let us bypass the host dropping the entire LDU frame when a LC is undecodable, and maintain the proper call data stream.

Additionally I've added some logging to display the number of undecodable LCs at the end of a call or a abrupt call termination.