### PR TITLE
Add NullModem support

### DIFF
--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -1119,7 +1119,7 @@ bool CMMDVMHost::createModem()
 	LogInfo("    RX Frequency: %uHz (%uHz)", rxFrequency, rxFrequency + rxOffset);
 	LogInfo("    TX Frequency: %uHz (%uHz)", txFrequency, txFrequency + txOffset);
 
-	m_modem = new CModem(port, m_duplex, rxInvert, txInvert, pttInvert, txDelay, dmrDelay, trace, debug);
+	m_modem = CModem::createModem(port, m_duplex, rxInvert, txInvert, pttInvert, txDelay, dmrDelay, trace, debug);
 	m_modem->setSerialParams(protocol,address);
 	m_modem->setModeParams(m_dstarEnabled, m_dmrEnabled, m_ysfEnabled, m_p25Enabled, m_nxdnEnabled, m_pocsagEnabled);
 	m_modem->setLevels(rxLevel, cwIdTXLevel, dstarTXLevel, dmrTXLevel, ysfTXLevel, p25TXLevel, nxdnTXLevel, pocsagTXLevel);

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OBJECTS = \
 		AMBEFEC.o BCH.o BPTC19696.o Conf.o CRC.o Display.o DMRControl.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREMB.o DMREmbeddedData.o DMRFullLC.o \
 		DMRLookup.o DMRLC.o DMRNetwork.o DMRShortLC.o DMRSlot.o DMRSlotType.o DMRAccessControl.o DMRTrellis.o DStarControl.o DStarHeader.o DStarNetwork.o \
 		DStarSlowData.o Golay2087.o Golay24128.o Hamming.o I2CController.o LCDproc.o Log.o MMDVMHost.o MobileGPS.o Modem.o ModemSerialPort.o Mutex.o NetworkInfo.o \
-		Nextion.o NullDisplay.o NXDNAudio.o NXDNControl.o NXDNConvolution.o NXDNCRC.o NXDNFACCH1.o NXDNLayer3.o NXDNLICH.o NXDNLookup.o NXDNNetwork.o \
+		Nextion.o NullDisplay.o NullModem.o NXDNAudio.o NXDNControl.o NXDNConvolution.o NXDNCRC.o NXDNFACCH1.o NXDNLayer3.o NXDNLICH.o NXDNLookup.o NXDNNetwork.o \
 		NXDNSACCH.o NXDNUDCH.o P25Audio.o P25Control.o P25Data.o P25LowSpeedData.o P25Network.o P25NID.o P25Trellis.o P25Utils.o POCSAGControl.o \
 		POCSAGNetwork.o QR1676.o RS129.o RS241213.o RSSIInterpolator.o SerialController.o SerialPort.o SHA256.o StopWatch.o Sync.o TFTSerial.o Thread.o \
 		Timer.o UDPSocket.o UMP.o Utils.o YSFControl.o YSFConvolution.o YSFFICH.o YSFNetwork.o YSFPayload.o

--- a/Modem.cpp
+++ b/Modem.cpp
@@ -25,6 +25,7 @@
 #include "POCSAGDefines.h"
 #include "Thread.h"
 #include "Modem.h"
+#include "NullModem.h"
 #include "Utils.h"
 #include "Log.h"
 
@@ -1825,4 +1826,11 @@ void CModem::printDebug()
 		short val4 = (m_buffer[m_length - 2U] << 8) | m_buffer[m_length - 1U];
 		LogMessage("Debug: %.*s %d %d %d %d", m_length - 11U, m_buffer + 3U, val1, val2, val3, val4);
 	}
+}
+
+CModem* CModem::createModem(const std::string& port, bool duplex, bool rxInvert, bool txInvert, bool pttInvert, unsigned int txDelay, unsigned int dmrDelay, bool trace, bool debug){
+	if (port == "NullModem")
+		return new CNullModem(port, duplex, rxInvert, txInvert, pttInvert, txDelay, dmrDelay, trace, debug);
+	else
+		return new CModem(port, duplex, rxInvert, txInvert, pttInvert, txDelay, dmrDelay, trace, debug);
 }

--- a/Modem.h
+++ b/Modem.h
@@ -35,75 +35,77 @@ enum RESP_TYPE_MMDVM {
 class CModem {
 public:
 	CModem(const std::string& port, bool duplex, bool rxInvert, bool txInvert, bool pttInvert, unsigned int txDelay, unsigned int dmrDelay, bool trace, bool debug);
-	~CModem();
+	virtual ~CModem();
 
-	void setSerialParams(const std::string& protocol, unsigned int address);
-	void setRFParams(unsigned int rxFrequency, int rxOffset, unsigned int txFrequency, int txOffset, int txDCOffset, int rxDCOffset, float rfLevel, unsigned int pocsagFrequency);
-	void setModeParams(bool dstarEnabled, bool dmrEnabled, bool ysfEnabled, bool p25Enabled, bool nxdnEnabled, bool pocsagEnabled);
-	void setLevels(float rxLevel, float cwIdTXLevel, float dstarTXLevel, float dmrTXLevel, float ysfTXLevel, float p25TXLevel, float nxdnTXLevel, float pocsagLevel);
-	void setDMRParams(unsigned int colorCode);
-	void setYSFParams(bool loDev, unsigned int txHang);
-	void setTransparentDataParams(unsigned int sendFrameType);
+	virtual void setSerialParams(const std::string& protocol, unsigned int address);
+	virtual void setRFParams(unsigned int rxFrequency, int rxOffset, unsigned int txFrequency, int txOffset, int txDCOffset, int rxDCOffset, float rfLevel, unsigned int pocsagFrequency);
+	virtual void setModeParams(bool dstarEnabled, bool dmrEnabled, bool ysfEnabled, bool p25Enabled, bool nxdnEnabled, bool pocsagEnabled);
+	virtual void setLevels(float rxLevel, float cwIdTXLevel, float dstarTXLevel, float dmrTXLevel, float ysfTXLevel, float p25TXLevel, float nxdnTXLevel, float pocsagLevel);
+	virtual void setDMRParams(unsigned int colorCode);
+	virtual void setYSFParams(bool loDev, unsigned int txHang);
+	virtual void setTransparentDataParams(unsigned int sendFrameType);
 
-	bool open();
+	virtual bool open();
 
-	unsigned int readDStarData(unsigned char* data);
-	unsigned int readDMRData1(unsigned char* data);
-	unsigned int readDMRData2(unsigned char* data);
-	unsigned int readYSFData(unsigned char* data);
-	unsigned int readP25Data(unsigned char* data);
-	unsigned int readNXDNData(unsigned char* data);
-	unsigned int readTransparentData(unsigned char* data);
+	virtual unsigned int readDStarData(unsigned char* data);
+	virtual unsigned int readDMRData1(unsigned char* data);
+	virtual unsigned int readDMRData2(unsigned char* data);
+	virtual unsigned int readYSFData(unsigned char* data);
+	virtual unsigned int readP25Data(unsigned char* data);
+	virtual unsigned int readNXDNData(unsigned char* data);
+	virtual unsigned int readTransparentData(unsigned char* data);
 
-	unsigned int readSerial(unsigned char* data, unsigned int length);
+	virtual unsigned int readSerial(unsigned char* data, unsigned int length);
 
-	bool hasDStarSpace() const;
-	bool hasDMRSpace1() const;
-	bool hasDMRSpace2() const;
-	bool hasYSFSpace() const;
-	bool hasP25Space() const;
-	bool hasNXDNSpace() const;
-	bool hasPOCSAGSpace() const;
+	virtual bool hasDStarSpace() const;
+	virtual bool hasDMRSpace1() const;
+	virtual bool hasDMRSpace2() const;
+	virtual bool hasYSFSpace() const;
+	virtual bool hasP25Space() const;
+	virtual bool hasNXDNSpace() const;
+	virtual bool hasPOCSAGSpace() const;
 
-	bool hasTX() const;
-	bool hasCD() const;
+	virtual bool hasTX() const;
+	virtual bool hasCD() const;
 
-	bool hasLockout() const;
-	bool hasError() const;
+	virtual bool hasLockout() const;
+	virtual bool hasError() const;
 
-	bool writeDStarData(const unsigned char* data, unsigned int length);
-	bool writeDMRData1(const unsigned char* data, unsigned int length);
-	bool writeDMRData2(const unsigned char* data, unsigned int length);
-	bool writeYSFData(const unsigned char* data, unsigned int length);
-	bool writeP25Data(const unsigned char* data, unsigned int length);
-	bool writeNXDNData(const unsigned char* data, unsigned int length);
-	bool writePOCSAGData(const unsigned char* data, unsigned int length);
+	virtual bool writeDStarData(const unsigned char* data, unsigned int length);
+	virtual bool writeDMRData1(const unsigned char* data, unsigned int length);
+	virtual bool writeDMRData2(const unsigned char* data, unsigned int length);
+	virtual bool writeYSFData(const unsigned char* data, unsigned int length);
+	virtual bool writeP25Data(const unsigned char* data, unsigned int length);
+	virtual bool writeNXDNData(const unsigned char* data, unsigned int length);
+	virtual bool writePOCSAGData(const unsigned char* data, unsigned int length);
 
-	bool writeTransparentData(const unsigned char* data, unsigned int length);
+	virtual bool writeTransparentData(const unsigned char* data, unsigned int length);
 
-	bool writeDStarInfo(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
-	bool writeDMRInfo(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type);
-	bool writeYSFInfo(const char* source, const char* dest, const char* type, const char* origin);
-	bool writeP25Info(const char* source, bool group, unsigned int dest, const char* type);
-	bool writeNXDNInfo(const char* source, bool group, unsigned int dest, const char* type);
-	bool writePOCSAGInfo(unsigned int ric, const std::string& message);
-	bool writeIPInfo(const std::string& address);
+	virtual bool writeDStarInfo(const char* my1, const char* my2, const char* your, const char* type, const char* reflector);
+	virtual bool writeDMRInfo(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type);
+	virtual bool writeYSFInfo(const char* source, const char* dest, const char* type, const char* origin);
+	virtual bool writeP25Info(const char* source, bool group, unsigned int dest, const char* type);
+	virtual bool writeNXDNInfo(const char* source, bool group, unsigned int dest, const char* type);
+	virtual bool writePOCSAGInfo(unsigned int ric, const std::string& message);
+	virtual bool writeIPInfo(const std::string& address);
 
-	bool writeDMRStart(bool tx);
-	bool writeDMRShortLC(const unsigned char* lc);
-	bool writeDMRAbort(unsigned int slotNo);
+	virtual bool writeDMRStart(bool tx);
+	virtual bool writeDMRShortLC(const unsigned char* lc);
+	virtual bool writeDMRAbort(unsigned int slotNo);
 
-	bool writeSerial(const unsigned char* data, unsigned int length);
+	virtual bool writeSerial(const unsigned char* data, unsigned int length);
 
-	bool setMode(unsigned char mode);
+	virtual bool setMode(unsigned char mode);
 
-	bool sendCWId(const std::string& callsign);
+	virtual bool sendCWId(const std::string& callsign);
 
-	HW_TYPE getHWType() const;
+	virtual HW_TYPE getHWType() const;
 
-	void clock(unsigned int ms);
+	virtual void clock(unsigned int ms);
 
-	void close();
+	virtual void close();
+
+	static CModem* createModem(const std::string& port, bool duplex, bool rxInvert, bool txInvert, bool pttInvert, unsigned int txDelay, unsigned int dmrDelay, bool trace, bool debug);
 
 private:
 	std::string                m_port;

--- a/NullModem.cpp
+++ b/NullModem.cpp
@@ -1,0 +1,35 @@
+/*
+ *   Copyright (C) 2011-2018 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "NullModem.h"
+#include "Log.h"
+
+CNullModem::CNullModem(const std::string& port, bool duplex, bool rxInvert, bool txInvert, bool pttInvert, unsigned int txDelay, unsigned int dmrDelay, bool trace, bool debug) :
+CModem(port, duplex,rxInvert, txInvert,pttInvert,txDelay, dmrDelay, trace, debug),
+m_hwType(HWT_MMDVM)
+{
+}
+
+CNullModem::~CNullModem()
+{
+}
+
+bool CNullModem::open(){
+	::LogMessage("Opening the MMDVM Null Modem");
+	return true;
+}

--- a/NullModem.h
+++ b/NullModem.h
@@ -1,0 +1,105 @@
+/*
+ *   Copyright (C) 2011-2018 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef	NULLMODEM_H
+#define	NULLMODEM_H
+
+#include "Modem.h"
+#include "Defines.h"
+
+#include <string>
+
+
+class CNullModem : public CModem {
+public:
+	CNullModem(const std::string& port, bool duplex, bool rxInvert, bool txInvert, bool pttInvert, unsigned int txDelay, unsigned int dmrDelay, bool trace, bool debug);
+	virtual ~CNullModem();
+
+	virtual void setSerialParams(const std::string& protocol, unsigned int address){};
+	virtual void setRFParams(unsigned int rxFrequency, int rxOffset, unsigned int txFrequency, int txOffset, int txDCOffset, int rxDCOffset, float rfLevel, unsigned int pocsagFrequency){};
+	virtual void setModeParams(bool dstarEnabled, bool dmrEnabled, bool ysfEnabled, bool p25Enabled, bool nxdnEnabled, bool pocsagEnabled){};
+	virtual void setLevels(float rxLevel, float cwIdTXLevel, float dstarTXLevel, float dmrTXLevel, float ysfTXLevel, float p25TXLevel, float nxdnTXLevel, float pocsagLevel){};
+	virtual void setDMRParams(unsigned int colorCode){};
+	virtual void setYSFParams(bool loDev, unsigned int txHang){};
+	virtual void setTransparentDataParams(unsigned int sendFrameType){};
+
+	virtual bool open();
+
+	virtual unsigned int readDStarData(unsigned char* data){return 0;};
+	virtual unsigned int readDMRData1(unsigned char* data){return 0;};
+	virtual unsigned int readDMRData2(unsigned char* data){return 0;};
+	virtual unsigned int readYSFData(unsigned char* data){return 0;};
+	virtual unsigned int readP25Data(unsigned char* data){return 0;};
+	virtual unsigned int readNXDNData(unsigned char* data){return 0;};
+	virtual unsigned int readTransparentData(unsigned char* data){return 0;};
+
+	virtual unsigned int readSerial(unsigned char* data, unsigned int length){return 0;};
+
+	virtual bool hasDStarSpace()const {return true;};
+	virtual bool hasDMRSpace1() const {return true;};
+	virtual bool hasDMRSpace2() const {return true;};
+	virtual bool hasYSFSpace() const  {return true;};
+	virtual bool hasP25Space() const  {return true;};
+	virtual bool hasNXDNSpace() const {return true;};
+	virtual bool hasPOCSAGSpace() const{return true;}; 
+
+	virtual bool hasTX() const {return false;};
+	virtual bool hasCD() const {return false;};
+
+	virtual bool hasLockout() const {return false;};
+	virtual bool hasError() const   {return false;};
+
+	virtual bool writeDStarData(const unsigned char* data, unsigned int length){return true;};
+	virtual bool writeDMRData1(const unsigned char* data, unsigned int length){return true;};
+	virtual bool writeDMRData2(const unsigned char* data, unsigned int length){return true;};
+	virtual bool writeYSFData(const unsigned char* data, unsigned int length){return true;};
+	virtual bool writeP25Data(const unsigned char* data, unsigned int length){return true;};
+	virtual bool writeNXDNData(const unsigned char* data, unsigned int length){return true;};
+	virtual bool writePOCSAGData(const unsigned char* data, unsigned int length){return true;};
+
+	virtual bool writeTransparentData(const unsigned char* data, unsigned int length){return true;};
+
+	virtual bool writeDStarInfo(const char* my1, const char* my2, const char* your, const char* type, const char* reflector){return true;};
+	virtual bool writeDMRInfo(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type){return true;};
+	virtual bool writeYSFInfo(const char* source, const char* dest, const char* type, const char* origin){return true;};
+	virtual bool writeP25Info(const char* source, bool group, unsigned int dest, const char* type){return true;};
+	virtual bool writeNXDNInfo(const char* source, bool group, unsigned int dest, const char* type){return true;};
+	virtual bool writePOCSAGInfo(unsigned int ric, const std::string& message){return true;};
+	virtual bool writeIPInfo(const std::string& address){return true;};
+
+	virtual bool writeDMRStart(bool tx){return true;};
+	virtual bool writeDMRShortLC(const unsigned char* lc){return true;};
+	virtual bool writeDMRAbort(unsigned int slotNo){return true;};
+
+	virtual bool writeSerial(const unsigned char* data, unsigned int length){return true;};
+
+	virtual bool setMode(unsigned char mode){return true;};
+
+	virtual bool sendCWId(const std::string& callsign){return true;};
+
+	virtual HW_TYPE getHWType() const {return m_hwType;};
+
+	virtual void clock(unsigned int ms){};
+
+	virtual void close(){};
+
+private:
+	HW_TYPE                    m_hwType;
+};
+
+#endif


### PR DESCRIPTION
This patch will allow MMDVMHost to start without real modem. To enable, just replace the modem port with "NullModem"