### PR TITLE
Fixed incorrect DMRTA header packet length from RF side

### DIFF
--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -630,7 +630,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 					if (!(m_rfTalkerId & TALKER_ID_HEADER)) {
 						if (m_rfTalkerId == TALKER_ID_NONE)
 							m_rfTalkerAlias.reset();
-						m_rfTalkerAlias.add(0, data, 6U);
+						m_rfTalkerAlias.add(0, data, 7U);
 						m_display->writeDMRTA(m_slotNo, (unsigned char*)m_rfTalkerAlias.get(), "R");
 
 						if (m_dumpTAData) {

--- a/DMRTA.h
+++ b/DMRTA.h
@@ -25,7 +25,7 @@ public:
     void reset();
 
 protected:
-    void decodeTA();
+    bool decodeTA();
 
 private:
     char            m_TA[32];


### PR DESCRIPTION
I don't know why, in the original source, the length of  FLCO_TALKER_ALIAS_HEADER packet is 6 from RF side while its 7 from NET side. 
According to the ts_10236102v020301p.pdf page 52, I believe all packet should be fixed to 7 bytes and the first byte of HEADER is used as control information.
Here is the fix to this issue.