### PR TITLE
Improvements to prevent corruption with OLED scrolling

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -220,10 +220,10 @@ bool COLED::open()
     m_display.clearDisplay();   // clears the screen  buffer
     m_display.display();        // display it (clear display)
 
-    OLED_statusbar();
+    drawStatusBar();
     m_display.setCursor(0,OLED_LINE3);
     m_display.print("Startup");
-    m_display.display();
+    drawDisplay();
 
     return true;
 }
@@ -231,17 +231,17 @@ bool COLED::open()
 void COLED::setIdleInt()
 {
     m_mode = MODE_IDLE;
-
+    m_display.stopscroll();
     m_display.clearDisplay();
-    OLED_statusbar();
+    drawStatusBar();
+    m_displayScrollMode = SCROLL_FULL_DISPLAY;
 
 //    m_display.setCursor(0,30);
 //    m_display.setTextSize(3);
 //    m_display.print("Idle");
-
 //    m_display.setTextSize(1);
-    m_display.startscrolldiagright(0x00,0x0f);  //the MMDVM logo scrolls the whole screen
-    m_display.display();
+
+    drawDisplay();
 
     unsigned char info[100U];
     CNetworkInfo* m_network;
@@ -270,50 +270,57 @@ void COLED::setErrorInt(const char* text)
 {
     m_mode = MODE_ERROR;
 
+    m_display.stopscroll();
     m_display.clearDisplay();
-    OLED_statusbar();
+    drawStatusBar();
 
     m_display.setCursor(0,OLED_LINE1);
     m_display.printf("%s\n",text);
 
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::setLockoutInt()
 {
     m_mode = MODE_LOCKOUT;
 
+    m_display.stopscroll();
     m_display.clearDisplay();
-    OLED_statusbar();
+    drawStatusBar();
 
     m_display.setCursor(0,30);
     m_display.setTextSize(3);
     m_display.print("Lockout");
 
     m_display.setTextSize(1);
-    m_display.display();
+    
+    drawDisplay();
 }
 
 void COLED::setQuitInt()
 {
     m_mode = MODE_QUIT;
 
+    m_display.stopscroll();
     m_display.clearDisplay();
-    OLED_statusbar();
+    drawStatusBar();
 
     m_display.setCursor(0,30);
     m_display.setTextSize(3);
     m_display.print("Stopped");
 
     m_display.setTextSize(1);
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::writeDStarInt(const char* my1, const char* my2, const char* your, const char* type, const char* reflector)
 {
     m_mode = MODE_DSTAR;
 
+    m_display.stopscroll();
     m_display.clearDisplay();
+    drawStatusBar();
+
     m_display.fillRect(0,OLED_LINE3,m_display.width(),m_display.height(),BLACK); //clear everything beneath logo
 
     m_display.setCursor(0,OLED_LINE3);
@@ -328,8 +335,7 @@ void COLED::writeDStarInt(const char* my1, const char* my2, const char* your, co
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    OLED_statusbar();
-    m_display.display();
+    drawDisplay();
 
     if (m_modem != NULL)
         m_modem->writeDStarInfo(my1, my2, your, type, reflector);
@@ -337,6 +343,7 @@ void COLED::writeDStarInt(const char* my1, const char* my2, const char* your, co
 
 void COLED::clearDStarInt()
 {
+    m_display.stopscroll();
     m_display.fillRect(0,OLED_LINE3, m_display.width(),m_display.height(),BLACK); //clear everything beneath the logo
 
     m_display.setCursor(40,OLED_LINE3);
@@ -345,17 +352,20 @@ void COLED::clearDStarInt()
     m_display.setCursor(0,OLED_LINE5);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::writeDMRInt(unsigned int slotNo,const std::string& src,bool group,const std::string& dst,const char* type)
 {
+    m_display.stopscroll();
 
     if (m_mode != MODE_DMR) {
         m_display.clearDisplay();
         m_mode = MODE_DMR;
         clearDMRInt(slotNo);
+        drawStatusBar();
     }
+
     // if both slots, use lines 2-3 for slot 1, lines 4-5 for slot 2
     // if single slot, use lines 3-4
     if ( m_slot1Enabled && m_slot2Enabled ) {
@@ -390,8 +400,7 @@ void COLED::writeDMRInt(unsigned int slotNo,const std::string& src,bool group,co
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    OLED_statusbar();
-    m_display.display();
+    drawDisplay();
 
     if (m_modem != NULL)
         m_modem->writeDMRInfo(slotNo, src, group, dst, type);
@@ -422,15 +431,16 @@ void COLED::clearDMRInt(unsigned int slotNo)
     m_display.fillRect(0, OLED_LINE6, m_display.width(), 20, BLACK);
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
-    m_display.display();
 }
 
 void COLED::writeFusionInt(const char* source, const char* dest, const char* type, const char* origin)
 {
-
     m_mode = MODE_YSF;
-
+    
+    m_display.stopscroll();
     m_display.clearDisplay();
+    drawStatusBar();
+
     m_display.fillRect(0,OLED_LINE2,m_display.width(),m_display.height(),BLACK);
 
     m_display.setCursor(0,OLED_LINE4);
@@ -439,8 +449,8 @@ void COLED::writeFusionInt(const char* source, const char* dest, const char* typ
     m_display.setCursor(0,OLED_LINE5);
     m_display.printf("  %.10s", dest);
 
-    OLED_statusbar();
-    m_display.display();
+    
+    drawDisplay();
 
     if (m_modem != NULL)
         m_modem->writeYSFInfo(source, dest, type, origin);
@@ -448,6 +458,7 @@ void COLED::writeFusionInt(const char* source, const char* dest, const char* typ
 
 void COLED::clearFusionInt()
 {
+    m_display.stopscroll();
     m_display.fillRect(0, OLED_LINE2, m_display.width(), m_display.height(), BLACK);
 
     m_display.setCursor(40,OLED_LINE4);
@@ -456,15 +467,17 @@ void COLED::clearFusionInt()
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::writeP25Int(const char* source, bool group, unsigned int dest, const char* type)
 {
     m_mode = MODE_P25;
 
+    m_display.stopscroll();
     m_display.clearDisplay();
     m_display.fillRect(0, OLED_LINE2, m_display.width(), m_display.height(), BLACK);
+    drawStatusBar();
 
     m_display.setCursor(0,OLED_LINE3);
     m_display.printf("%s %.10s", type, source);
@@ -472,8 +485,8 @@ void COLED::writeP25Int(const char* source, bool group, unsigned int dest, const
     m_display.setCursor(0,OLED_LINE4);
     m_display.printf("  %s%u", group ? "TG" : "", dest);
 
-    OLED_statusbar();
-    m_display.display();
+    
+    drawDisplay();
 
     if (m_modem != NULL)
         m_modem->writeP25Info(source, group, dest, type);
@@ -481,6 +494,7 @@ void COLED::writeP25Int(const char* source, bool group, unsigned int dest, const
 
 void COLED::clearP25Int()
 {
+    m_display.stopscroll();
     m_display.fillRect(0, OLED_LINE2, m_display.width(), m_display.height(), BLACK);
 
     m_display.setCursor(40,OLED_LINE4);
@@ -489,14 +503,17 @@ void COLED::clearP25Int()
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::writeNXDNInt(const char* source, bool group, unsigned int dest, const char* type)
 {
     m_mode = MODE_NXDN;
 
+    m_display.stopscroll();
     m_display.clearDisplay();
+    drawStatusBar();
+
     m_display.fillRect(0, OLED_LINE2, m_display.width(), m_display.height(), BLACK);
 
     m_display.setCursor(0,OLED_LINE3);
@@ -505,8 +522,7 @@ void COLED::writeNXDNInt(const char* source, bool group, unsigned int dest, cons
     m_display.setCursor(0,OLED_LINE5);
     m_display.printf("  %s%u", group ? "TG" : "", dest);
 
-    OLED_statusbar();
-    m_display.display();
+    drawDisplay();
 
     if (m_modem != NULL)
         m_modem->writeNXDNInfo(source, group, dest, type);
@@ -514,6 +530,8 @@ void COLED::writeNXDNInt(const char* source, bool group, unsigned int dest, cons
 
 void COLED::clearNXDNInt()
 {
+    m_display.stopscroll();
+
     m_display.fillRect(0, OLED_LINE2, m_display.width(), m_display.height(), BLACK);
 
     m_display.setCursor(40,OLED_LINE4);
@@ -522,14 +540,16 @@ void COLED::clearNXDNInt()
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::writePOCSAGInt(uint32_t ric, const std::string& message)
 {
     m_mode = MODE_POCSAG;
-
+    
+    m_display.stopscroll();
     m_display.clearDisplay();
+    drawStatusBar();
     m_display.fillRect(0, OLED_LINE1, m_display.width(), m_display.height(), BLACK);
 
     m_display.setCursor(0,OLED_LINE3);
@@ -538,8 +558,8 @@ void COLED::writePOCSAGInt(uint32_t ric, const std::string& message)
     m_display.setCursor(0,OLED_LINE5);
     m_display.printf("MSG: %s", message.c_str());
 
-    OLED_statusbar();
-    m_display.display();
+    
+    drawDisplay();
 
     if (m_modem != NULL)
         m_modem->writePOCSAGInfo(ric, message);
@@ -547,6 +567,8 @@ void COLED::writePOCSAGInt(uint32_t ric, const std::string& message)
 
 void COLED::clearPOCSAGInt()
 {
+    m_display.stopscroll();
+
     m_display.fillRect(0, OLED_LINE1, m_display.width(), m_display.height(), BLACK);
 
     m_display.setCursor(40,OLED_LINE4);
@@ -555,11 +577,12 @@ void COLED::clearPOCSAGInt()
     m_display.setCursor(0,OLED_LINE6);
     m_display.printf("%s",m_ipaddress.c_str());
 
-    m_display.display();
+    drawDisplay();
 }
 
 void COLED::writeCWInt()
 {
+    m_display.stopscroll();
     m_display.clearDisplay();
 
     m_display.setCursor(0,30);
@@ -567,12 +590,14 @@ void COLED::writeCWInt()
     m_display.print("CW TX");
 
     m_display.setTextSize(1);
-    m_display.display();
-    m_display.startscrollright(0x02,0x0f);
+    
+    m_displayScrollMode = SCROLL_BOTTOM_DISPLAY;
+    drawDisplay();
 }
 
 void COLED::clearCWInt()
 {
+    m_display.stopscroll();
     m_display.clearDisplay();
 
     m_display.setCursor(0,30);
@@ -580,26 +605,27 @@ void COLED::clearCWInt()
     m_display.print("Idle");
 
     m_display.setTextSize(1);
-    m_display.display();
-    m_display.startscrollleft(0x02,0x0f);
+    
+    m_displayScrollMode = SCROLL_BOTTOM_DISPLAY;
+    drawDisplay();
 }
 
 void COLED::close()
 {
+    m_display.stopscroll();
     m_display.clearDisplay();
     m_display.fillRect(0, 0, m_display.width(), 16, BLACK);
-    m_display.startscrollright(0x00,0x01);
     m_display.setCursor(0,00);
     m_display.setTextSize(2);
     m_display.print("-CLOSE-");
-    m_display.display();
+    m_displayScrollMode = SCROLL_STATUS_BAR;
+    drawDisplay();
 
     m_display.close();
 }
 
-void COLED::OLED_statusbar()
+void COLED::drawStatusBar()
 {
-    m_display.stopscroll();
     m_display.fillRect(0, 0, m_display.width(), 16, BLACK);
     m_display.setTextColor(WHITE);
 
@@ -619,6 +645,16 @@ void COLED::OLED_statusbar()
     else
         m_display.drawBitmap(0, 0, logo_glcd_bmp, 128, 16, WHITE);
 
-    if (m_displayScroll)
-        m_display.startscrollright(0x00,0x01);
+    m_displayScrollMode = SCROLL_STATUS_BAR;
+}
+
+void COLED::drawDisplay() 
+{
+    m_display.display();
+    if (m_displayScrollMode == SCROLL_STATUS_BAR)
+        m_display.startscrollright(0x00,0x01);   // Just the title bar scrolls.
+    else if (m_displayScrollMode == SCROLL_FULL_DISPLAY)
+        m_display.startscrolldiagright(0x00,0x0f);  //the MMDVM logo scrolls the whole screen
+    else if (m_displayScrollMode == SCROLL_BOTTOM_DISPLAY)
+        m_display.startscrollright(0x02,0x0f);
 }

--- a/OLED.h
+++ b/OLED.h
@@ -38,6 +38,12 @@
 #include "NetworkInfo.h"
 #include "Modem.h"
 
+// Display Scroll Modes
+#define SCROLL_NONE 0
+#define SCROLL_STATUS_BAR 1
+#define SCROLL_FULL_DISPLAY 2
+#define SCROLL_BOTTOM_DISPLAY 3
+
 class COLED : public CDisplay 
 {
 public:
@@ -70,8 +76,11 @@ public:
   virtual void writePOCSAGInt(uint32_t ric, const std::string& message);
   virtual void clearPOCSAGInt();
 
+  virtual void drawStatusBar();
+
   virtual void writeCWInt();
   virtual void clearCWInt();
+  virtual void drawDisplay();
 
   virtual void close();
 
@@ -81,6 +90,7 @@ private:
   unsigned char m_mode;
   unsigned char m_displayType;
   unsigned char m_displayBrightness;
+  unsigned char m_displayScrollMode;
   bool          m_displayInvert;
   bool          m_displayScroll;
   bool          m_displayRotate;
@@ -89,8 +99,6 @@ private:
   CModem*       m_modem;
   std::string   m_ipaddress;
   ArduiPi_OLED  m_display;
-
-  void OLED_statusbar();
 };
 
 #endif


### PR DESCRIPTION
Okay, so don't accept this one without a little bit of testing.  I only have a DMR radio so I can't test the other modes (P25, DSTAR, etc.)

In my research I have found that the SSD1306 has limited RAM and when the scrolling modes are used you kind of need to do things in a specific order -- Stop scrolling, draw, start scrolling again.   Otherwise you get display memory corruption.

This pull request tries to centralize the draw/scroll method in a single place, and keep display transactions standardized in this manner.

The `writeCWInt` and `clearCWInt` functions use a different kind fo scrolling than the StatusBar and Idle scrolling, so that should probably be tested too.

In my use with DMR radio, the display is much more stable with this code.