### PR TITLE
Add OpenBSD support

### DIFF
--- a/I2CController.cpp
+++ b/I2CController.cpp
@@ -63,7 +63,7 @@ int CI2CController::write(const unsigned char* buffer, unsigned int length)
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
-#if !defined(__APPLE__)
+#if defined(__linux__)
 #include <linux/i2c-dev.h>
 #endif
 
@@ -81,7 +81,7 @@ bool CI2CController::open()
 {
 	assert(m_fd == -1);
 
-#if !defined(__APPLE__)
+#if defined(__linux__)
 	m_fd = ::open(m_device.c_str(), O_RDWR);
 	if (m_fd < 0) {
 		LogError("Cannot open device - %s", m_device.c_str());
@@ -100,7 +100,7 @@ bool CI2CController::open()
 		return false;
 	}
 #else
-	#warning "I2C controller does not support OSX"
+	#warning "I2C controller supports Linux only"
 #endif
 
 	return true;
@@ -117,7 +117,7 @@ int CI2CController::read(unsigned char* buffer, unsigned int length)
 	unsigned int offset = 0U;
 
 	while (offset < length) {
-#if !defined(__APPLE__)
+#if defined(__linux__)
 		ssize_t n = ::read(m_fd, buffer + offset, 1U);
 		if (n < 0) {
 			if (errno != EAGAIN) {
@@ -145,7 +145,7 @@ int CI2CController::write(const unsigned char* buffer, unsigned int length)
 	unsigned int ptr = 0U;
 	while (ptr < length) {
 		ssize_t n = 0U;
-#if !defined(__APPLE__)
+#if defined(__linux__)
 		n = ::write(m_fd, buffer + ptr, 1U);
 #endif
 		if (n < 0) {

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This makefile is for all platforms, but doesn't include support for the HD44780, OLED, or PCF8574 displays on the Raspberry Pi.
 
-CC      = gcc
-CXX     = g++
+CC      = cc
+CXX     = c++
 CFLAGS  = -g -O3 -Wall -std=c++0x -pthread
 LIBS    = -lpthread
 LDFLAGS = -g

--- a/NetworkInfo.cpp
+++ b/NetworkInfo.cpp
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #if !defined(_WIN32) && !defined(_WIN64)
 #include <ifaddrs.h>
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>

--- a/SerialController.cpp
+++ b/SerialController.cpp
@@ -35,9 +35,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
-#if !defined(__APPLE__)
-#include <linux/i2c-dev.h>
-#endif
 #endif
 
 


### PR DESCRIPTION
I tried to build MMDVMHost on OpenBSD-6.4/amd64 and there needs
some changes.

MMDVMHost is well-considered about portability, but some codes are still
Linux dependent. So this request reduces this problem.