### PR TITLE
Anyone need OLED status bar bitmap load and display function?

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -591,7 +591,7 @@ void COLED::close()
 
 void COLED::OLED_statusbar()
 {
-	m_display.stopscroll();
+    m_display.stopscroll();
     m_display.fillRect(0, 0, m_display.width(), 16, BLACK);
     m_display.setTextColor(WHITE);
 

--- a/OLED.h
+++ b/OLED.h
@@ -37,6 +37,32 @@
 #include "ArduiPi_OLED.h"
 #include "NetworkInfo.h"
 
+#pragma pack(1) 
+
+struct BMP_FILEHEADER{
+unsigned short  bfType;     //2Bytes, Should be "BM"，for Bitmap reserve.
+unsigned int    bfSize;     //4Bytes, Whole file size.
+unsigned short  bfReserved1;//2Bytes, Reserved should be 0.
+unsigned short  bfReserved2;//2Bytes, Reserved should be 0.
+unsigned int    bfOffBits;  //4Bytes, Pixel data  offset.
+};
+
+struct BMP_INFOHEADER{
+unsigned int    biSize;         //4Bytes, Size of INFOHEADER struct.
+unsigned int    biWidth;        //4Bytes, Width for image, in pixels.
+int             biHeight;       //4Bytes, Height for image, in pixels.
+unsigned short  biPlanes;       //2Bytes, Data planes, should be 1.
+unsigned short  biBitCount;     //2Bytes, Data bit count in colors, should be 1 in monochrome.
+unsigned int    biCompression;  //4Bytes, 0:No compress, 1:RLE8, 2:RLE4.
+unsigned int    biSizeImage;    //4Bytes, Image size in Byte.
+unsigned int    biXPelsPerMeter;//4Bytes, Horizontal resolution in pixels/meter.
+unsigned int    biYPelsPerMeter;//4Bytes, Vertical resolution in pixels/meter.
+unsigned int    biClrUsed;      //4Bytes, 
+unsigned int    biClrImportant; //4Bytes, 
+};
+
+#pragma pack() 
+
 class COLED : public CDisplay 
 {
 public:
@@ -73,6 +99,8 @@ public:
   virtual void clearCWInt();
 
   virtual void close();
+
+  virtual bool readBMPLogo(const char *filename, unsigned char *logo_array);
 
 private:
   const char*   m_slot1_state;


### PR DESCRIPTION
Hi all, 

I have add the bitmap file read function for OLED status bar display. Which could make the OLED screen on hotspot more fancy.
Here is some real OLED display sample.  
![Actra](https://user-images.githubusercontent.com/25135020/62068534-c69c8480-b268-11e9-9ab6-53e436c89199.jpg)

And here is the 7 different bitmap file. Generated by microsoft paint program.
![FileName](https://user-images.githubusercontent.com/25135020/62068670-167b4b80-b269-11e9-9bba-5e2e12edac69.jpg)

And, let me introduce those code. 
After OLED initialize, it will detect and load 7 bitmap files with the 7 different mode. If there is no expect filename or file format error, it will use original logo file where inside OLED.cpp and leave some thing in log.
Also two bitmap file header structs and  were added in OLED.h.

Please review my code and fell free to contact me if any improvement needed.
Thanks a lot.