### PR TITLE
Introducing LogoScreensaver=1 or 0 parameter for blanking OLED display

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -237,6 +237,7 @@ m_oledBrightness(0U),
 m_oledInvert(false),
 m_oledScroll(false),
 m_oledRotate(false),
+m_oledLogoScreensaver(true),
 m_lcdprocAddress(),
 m_lcdprocPort(0U),
 m_lcdprocLocalPort(0U),
@@ -790,6 +791,8 @@ bool CConf::read()
 			m_oledScroll = ::atoi(value) == 1;
 		else if (::strcmp(key, "Rotate") == 0)
 			m_oledRotate = ::atoi(value) == 1;
+		else if (::strcmp(key, "LogoScreensaver") == 0)
+			m_oledLogoScreensaver = ::atoi(value) == 1;
 	} else if (section == SECTION_LCDPROC) {
 		if (::strcmp(key, "Address") == 0)
 			m_lcdprocAddress = value;
@@ -1696,6 +1699,11 @@ bool CConf::getOLEDScroll() const
 bool CConf::getOLEDRotate() const
 {
 	return m_oledRotate;
+}
+
+bool CConf::getOLEDLogoScreensaver() const
+{
+	return m_oledLogoScreensaver;
 }
 
 

--- a/Conf.h
+++ b/Conf.h
@@ -254,6 +254,7 @@ public:
   bool           getOLEDInvert() const;
   bool           getOLEDScroll() const;
   bool           getOLEDRotate() const;
+  bool		 getOLEDLogoScreensaver() const;
 
   // The LCDproc section
   std::string  getLCDprocAddress() const;
@@ -477,6 +478,7 @@ private:
   bool          m_oledInvert;
   bool          m_oledScroll;
   bool          m_oledRotate;
+  bool		m_oledLogoScreensaver;
 
   std::string  m_lcdprocAddress;
   unsigned int m_lcdprocPort;

--- a/Display.cpp
+++ b/Display.cpp
@@ -569,8 +569,9 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CUMP* ump, CModem* modem)
 	        bool          invert     = conf.getOLEDInvert();
 	        bool          scroll     = conf.getOLEDScroll();
 		bool          rotate     = conf.getOLEDRotate();
+		bool          logosaver  = conf.getOLEDLogoScreensaver();
 
-		display = new COLED(type, brightness, invert, scroll, rotate, conf.getDMRNetworkSlot1(), conf.getDMRNetworkSlot2());
+		display = new COLED(type, brightness, invert, scroll, rotate, logosaver, conf.getDMRNetworkSlot1(), conf.getDMRNetworkSlot2());
 #endif
 	} else if (type == "CAST") {
 		display = new CCASTInfo(modem);

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -234,6 +234,7 @@ Invert=0
 Scroll=1
 Rotate=0
 Cast=0
+LogoScreensaver=1
 
 [LCDproc]
 Address=localhost

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -169,12 +169,13 @@ const unsigned char logo_POCSAG_bmp [] =
 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 };
 
-COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert, bool displayScroll, bool displayRotate, bool slot1Enabled, bool slot2Enabled) :
+COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert, bool displayScroll, bool displayRotate, bool displayLogoScreensaver, bool slot1Enabled, bool slot2Enabled) :
 m_displayType(displayType),
 m_displayBrightness(displayBrightness),
 m_displayInvert(displayInvert),
 m_displayScroll(displayScroll),
 m_displayRotate(displayRotate),
+m_displayLogoScreensaver(displayLogoScreensaver),
 m_slot1Enabled(slot1Enabled),
 m_slot2Enabled(slot2Enabled),
 m_ipaddress(),
@@ -600,7 +601,7 @@ void COLED::OLED_statusbar()
         m_display.drawBitmap(0, 0, logo_NXDN_bmp, 128, 16, WHITE);
     else if (m_mode == MODE_POCSAG)
         m_display.drawBitmap(0, 0, logo_POCSAG_bmp, 128, 16, WHITE);
-    else
+    else if (m_displayLogoScreensaver)
         m_display.drawBitmap(0, 0, logo_glcd_bmp, 128, 16, WHITE);
 
     if (m_displayScroll)

--- a/OLED.h
+++ b/OLED.h
@@ -40,7 +40,7 @@
 class COLED : public CDisplay 
 {
 public:
-  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert, bool displayScroll, bool displayRotate, bool slot1Enabled, bool slot2Enabled);
+  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert, bool displayScroll, bool displayRotate, bool displayLogoScreensaver, bool slot1Enabled, bool slot2Enabled);
   virtual ~COLED();
 
   virtual bool open();
@@ -83,6 +83,7 @@ private:
   bool          m_displayInvert;
   bool          m_displayScroll;
   bool          m_displayRotate;
+  bool		m_displayLogoScreensaver;
   bool          m_slot1Enabled;
   bool          m_slot2Enabled;
   std::string   m_ipaddress;


### PR DESCRIPTION
I've added configuration parameter LogoScreensaver which allows to disable scrolling screensaver logo. It just blanks the screen instead.