### PR TITLE
DStar SelfOnly with WhiteList

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -123,6 +123,7 @@ m_dstarEnabled(false),
 m_dstarModule("C"),
 m_dstarSelfOnly(false),
 m_dstarBlackList(),
+m_dstarWhiteList(),
 m_dstarAckReply(true),
 m_dstarAckTime(750U),
 m_dstarAckMessage(false),
@@ -513,7 +514,19 @@ bool CConf::read()
 				}
 				p = ::strtok(NULL, ",\r\n");
 			}
-		} else if (::strcmp(key, "AckReply") == 0)
+		} else if (::strcmp(key, "WhiteList") == 0) {
+                        char* p = ::strtok(value, ",\r\n");
+                        while (p != NULL) {
+                                if (::strlen(p) > 0U) {
+                                        for (unsigned int i = 0U; p[i] != 0; i++)
+                                                p[i] = ::toupper(p[i]);
+                                        std::string callsign = std::string(p);
+                                        callsign.resize(DSTAR_LONG_CALLSIGN_LENGTH, ' ');
+                                        m_dstarWhiteList.push_back(callsign);
+                                }
+                                p = ::strtok(NULL, ",\r\n");
+                        }
+                } else if (::strcmp(key, "AckReply") == 0)
 			m_dstarAckReply = ::atoi(value) == 1;
 		else if (::strcmp(key, "AckTime") == 0)
 			m_dstarAckTime = (unsigned int)::atoi(value);
@@ -1134,6 +1147,11 @@ bool CConf::getDStarSelfOnly() const
 std::vector<std::string> CConf::getDStarBlackList() const
 {
 	return m_dstarBlackList;
+}
+
+std::vector<std::string> CConf::getDStarWhiteList() const
+{
+        return m_dstarWhiteList;
 }
 
 bool CConf::getDStarAckReply() const

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -526,7 +526,7 @@ bool CConf::read()
                                 }
                                 p = ::strtok(NULL, ",\r\n");
                         }
-                } else if (::strcmp(key, "AckReply") == 0)
+		} else if (::strcmp(key, "AckReply") == 0)
 			m_dstarAckReply = ::atoi(value) == 1;
 		else if (::strcmp(key, "AckTime") == 0)
 			m_dstarAckTime = (unsigned int)::atoi(value);

--- a/Conf.h
+++ b/Conf.h
@@ -110,6 +110,7 @@ public:
   std::string  getDStarModule() const;
   bool         getDStarSelfOnly() const;
   std::vector<std::string> getDStarBlackList() const;
+  std::vector<std::string> getDStarWhiteList() const;
   bool         getDStarAckReply() const;
   unsigned int getDStarAckTime() const;
   bool         getDStarAckMessage() const;
@@ -349,6 +350,7 @@ private:
   std::string  m_dstarModule;
   bool         m_dstarSelfOnly;
   std::vector<std::string> m_dstarBlackList;
+  std::vector<std::string> m_dstarWhiteList;
   bool         m_dstarAckReply;
   unsigned int m_dstarAckTime;
   bool         m_dstarAckMessage;

--- a/DStarControl.cpp
+++ b/DStarControl.cpp
@@ -36,7 +36,7 @@ bool CallsignCompare(const std::string& arg, const unsigned char* my)
 
 // #define	DUMP_DSTAR
 
-CDStarControl::CDStarControl(const std::string& callsign, const std::string& module, bool selfOnly, bool ackReply, unsigned int ackTime, bool ackMessage, bool errorReply, const std::vector<std::string>& blackList, CDStarNetwork* network, CDisplay* display, unsigned int timeout, bool duplex, bool remoteGateway, CRSSIInterpolator* rssiMapper) :
+CDStarControl::CDStarControl(const std::string& callsign, const std::string& module, bool selfOnly, bool ackReply, unsigned int ackTime, bool ackMessage, bool errorReply, const std::vector<std::string>& blackList, const std::vector<std::string>& whiteList, CDStarNetwork* network, CDisplay* display, unsigned int timeout, bool duplex, bool remoteGateway, CRSSIInterpolator* rssiMapper) :
 m_callsign(NULL),
 m_gateway(NULL),
 m_selfOnly(selfOnly),
@@ -45,6 +45,7 @@ m_ackMessage(ackMessage),
 m_errorReply(errorReply),
 m_remoteGateway(remoteGateway),
 m_blackList(blackList),
+m_whiteList(whiteList),
 m_network(network),
 m_display(display),
 m_duplex(duplex),
@@ -231,7 +232,7 @@ bool CDStarControl::writeModem(unsigned char *data, unsigned int len)
 			return false;
 		}
 
-		if (m_selfOnly && ::memcmp(my1, m_callsign, DSTAR_LONG_CALLSIGN_LENGTH - 1U) != 0) {
+		if (m_selfOnly && ::memcmp(my1, m_callsign, DSTAR_LONG_CALLSIGN_LENGTH - 1U) != 0 && !(std::find_if(m_whiteList.begin(), m_whiteList.end(), std::bind(CallsignCompare, std::placeholders::_1, my1)) != m_whiteList.end())) {
 			LogMessage("D-Star, invalid access attempt from %8.8s", my1);
 			m_rfState = RS_RF_REJECTED;
 			return false;
@@ -465,7 +466,7 @@ bool CDStarControl::writeModem(unsigned char *data, unsigned int len)
 				return false;
 			}
 
-			if (m_selfOnly && ::memcmp(my1, m_callsign, DSTAR_LONG_CALLSIGN_LENGTH - 1U) != 0) {
+			if (m_selfOnly && ::memcmp(my1, m_callsign, DSTAR_LONG_CALLSIGN_LENGTH - 1U) != 0 && !(std::find_if(m_whiteList.begin(), m_whiteList.end(), std::bind(CallsignCompare, std::placeholders::_1, my1)) != m_whiteList.end())) {
 				LogMessage("D-Star, invalid access attempt from %8.8s", my1);
 				m_rfState = RS_RF_REJECTED;
 				delete header;

--- a/DStarControl.h
+++ b/DStarControl.h
@@ -37,7 +37,7 @@
 
 class CDStarControl {
 public:
-	CDStarControl(const std::string& callsign, const std::string& module, bool selfOnly, bool ackReply, unsigned int ackTime, bool ackMessage, bool errorReply, const std::vector<std::string>& blackList, CDStarNetwork* network, CDisplay* display, unsigned int timeout, bool duplex, bool remoteGateway, CRSSIInterpolator* rssiMapper);
+	CDStarControl(const std::string& callsign, const std::string& module, bool selfOnly, bool ackReply, unsigned int ackTime, bool ackMessage, bool errorReply, const std::vector<std::string>& blackList, const std::vector<std::string>& whiteList, CDStarNetwork* network, CDisplay* display, unsigned int timeout, bool duplex, bool remoteGateway, CRSSIInterpolator* rssiMapper);
 	~CDStarControl();
 
 	bool writeModem(unsigned char* data, unsigned int len);
@@ -59,6 +59,7 @@ private:
 	bool                       m_errorReply;
 	bool                       m_remoteGateway;
 	std::vector<std::string>   m_blackList;
+        std::vector<std::string>   m_whiteList;
 	CDStarNetwork*             m_network;
 	CDisplay*                  m_display;
 	bool                       m_duplex;

--- a/DStarControl.h
+++ b/DStarControl.h
@@ -59,7 +59,7 @@ private:
 	bool                       m_errorReply;
 	bool                       m_remoteGateway;
 	std::vector<std::string>   m_blackList;
-        std::vector<std::string>   m_whiteList;
+	std::vector<std::string>   m_whiteList;
 	CDStarNetwork*             m_network;
 	CDisplay*                  m_display;
 	bool                       m_duplex;

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -91,6 +91,7 @@ AckMessage=0
 ErrorReply=1
 RemoteGateway=0
 # ModeHang=10
+WhiteList=
 
 [DMR]
 Enable=1

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -402,7 +402,7 @@ int CMMDVMHost::run()
 		std::string module                 = m_conf.getDStarModule();
 		bool selfOnly                      = m_conf.getDStarSelfOnly();
 		std::vector<std::string> blackList = m_conf.getDStarBlackList();
-                std::vector<std::string> whiteList = m_conf.getDStarWhiteList();
+		std::vector<std::string> whiteList = m_conf.getDStarWhiteList();
 		bool ackReply                      = m_conf.getDStarAckReply();
 		unsigned int ackTime               = m_conf.getDStarAckTime();
 		bool ackMessage                    = m_conf.getDStarAckMessage();
@@ -422,8 +422,8 @@ int CMMDVMHost::run()
 
 		if (blackList.size() > 0U)
 			LogInfo("    Black List: %u", blackList.size());
-                if (whiteList.size() > 0U)
-                        LogInfo("    White List: %u", whiteList.size());
+		if (whiteList.size() > 0U)
+			LogInfo("    White List: %u", whiteList.size());
 
 		m_dstar = new CDStarControl(m_callsign, module, selfOnly, ackReply, ackTime, ackMessage, errorReply, blackList, whiteList, m_dstarNetwork, m_display, m_timeout, m_duplex, remoteGateway, rssi);
 	}

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -402,6 +402,7 @@ int CMMDVMHost::run()
 		std::string module                 = m_conf.getDStarModule();
 		bool selfOnly                      = m_conf.getDStarSelfOnly();
 		std::vector<std::string> blackList = m_conf.getDStarBlackList();
+                std::vector<std::string> whiteList = m_conf.getDStarWhiteList();
 		bool ackReply                      = m_conf.getDStarAckReply();
 		unsigned int ackTime               = m_conf.getDStarAckTime();
 		bool ackMessage                    = m_conf.getDStarAckMessage();
@@ -421,8 +422,10 @@ int CMMDVMHost::run()
 
 		if (blackList.size() > 0U)
 			LogInfo("    Black List: %u", blackList.size());
+                if (whiteList.size() > 0U)
+                        LogInfo("    White List: %u", whiteList.size());
 
-		m_dstar = new CDStarControl(m_callsign, module, selfOnly, ackReply, ackTime, ackMessage, errorReply, blackList, m_dstarNetwork, m_display, m_timeout, m_duplex, remoteGateway, rssi);
+		m_dstar = new CDStarControl(m_callsign, module, selfOnly, ackReply, ackTime, ackMessage, errorReply, blackList, whiteList, m_dstarNetwork, m_display, m_timeout, m_duplex, remoteGateway, rssi);
 	}
 
 	CTimer dmrBeaconIntervalTimer(1000U);


### PR DESCRIPTION
In DStar SelfOnly mode allow WhiteList callsigns to transmit.