### PR TITLE
Fix issue in DMRLC.cpp

### DIFF
--- a/DMRLC.cpp
+++ b/DMRLC.cpp
@@ -186,15 +186,15 @@ void CDMRLC::setFID(unsigned char fid)
 
 bool CDMRLC::getOVCM() const
 {
-	return (m_options & 0x20U) == 0x20U;
+	return (m_options & 0x04U) == 0x04U;
 }
 
 void CDMRLC::setOVCM(bool ovcm)
 {
 	if (ovcm)
-		m_options |= 0x20U;
+		m_options |= 0x04U;
 	else
-		m_options &= 0xDFU;
+		m_options &= 0xFBU;
 }
 
 unsigned int CDMRLC::getSrcId() const


### PR DESCRIPTION
The position of the OVCM bit was counted from the wrong end of the byte - fixed this (DK5MP and me had the same issue when we made our first OVCM tests)...