### PR TITLE
add displaying user information from DMR-MARC's user file (CSV format).

### DIFF
--- a/DMRLookup.h
+++ b/DMRLookup.h
@@ -36,6 +36,7 @@ public:
 
 	std::string find(unsigned int id);
 	std::string findWithName(unsigned int id);
+	void findUserInfo(unsigned int id, std::string& name, std::string& city, std::string& state, std::string& country);
 
 	bool exists(unsigned int id);
 
@@ -45,10 +46,16 @@ private:
 	std::string                                   m_filename;
 	unsigned int                                  m_reloadTime;
 	std::unordered_map<unsigned int, std::string> m_table;
+	std::unordered_map<unsigned int, std::string> m_tableName;
+	std::unordered_map<unsigned int, std::string> m_tableCity;
+	std::unordered_map<unsigned int, std::string> m_tableState;
+	std::unordered_map<unsigned int, std::string> m_tableCountry;
 	CMutex                                        m_mutex;
 	bool                                          m_stop;
 
 	bool load();
+	bool loadcsv();
+	char* tokenize(char *str, char **next);
 };
 
 #endif

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -1103,7 +1103,10 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 		std::string src = m_lookup->find(srcId);
 		std::string dst = m_lookup->find(dstId);
 		std::string cn = m_lookup->findWithName(srcId);
+		std::string dst_name, dst_city, dst_state, dst_country;
+		m_lookup->findUserInfo(srcId, dst_name, dst_city, dst_state, dst_country);
 		m_display->writeDMR(m_slotNo, cn, flco == FLCO_GROUP, dst, "N");
+		m_display->writeDMRUser(m_slotNo, dst_name, dst_city, dst_state, dst_country);
 
 #if defined(DUMP_DMR)
 		openFile();

--- a/Display.cpp
+++ b/Display.cpp
@@ -151,6 +151,11 @@ void CDisplay::writeDMR(unsigned int slotNo, const std::string& src, bool group,
 	writeDMRInt(slotNo, src, group, dst, type);
 }
 
+void CDisplay::writeDMRUser(unsigned int slotNo, const std::string& name, std::string& city, std::string &state, std::string &country)
+{
+	writeDMRUserInt(slotNo, name, city, state, country);
+}
+
 void CDisplay::writeDMRRSSI(unsigned int slotNo, unsigned char rssi)
 {
 	if (rssi != 0U)
@@ -383,6 +388,10 @@ void CDisplay::writeDStarRSSIInt(unsigned char rssi)
 }
 
 void CDisplay::writeDStarBERInt(float ber)
+{
+}
+
+void CDisplay::writeDMRUserInt(unsigned int slotNo, const std::string& name, std::string& city, std::string &state, std::string &country)
 {
 }
 

--- a/Display.h
+++ b/Display.h
@@ -48,6 +48,7 @@ public:
 	void clearDStar();
 
 	void writeDMR(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type);
+	void writeDMRUser(unsigned int slotNo, const std::string& name, std::string& city, std::string &state, std::string &country);
 	void writeDMRRSSI(unsigned int slotNo, unsigned char rssi);
 	void writeDMRBER(unsigned int slotNo, float ber);
 	void writeDMRTA(unsigned int slotNo, unsigned char* talkerAlias, const char* type);
@@ -91,6 +92,7 @@ protected:
 	virtual void clearDStarInt() = 0;
 
 	virtual void writeDMRInt(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type) = 0;
+	virtual void writeDMRUserInt(unsigned int slotNo, const std::string& name, std::string& city, std::string &state, std::string &country);
 	virtual void writeDMRRSSIInt(unsigned int slotNo, unsigned char rssi);
 	virtual void writeDMRTAInt(unsigned int slotNo, unsigned char* talkerAlias, const char* type);
 	virtual void writeDMRBERInt(unsigned int slotNo, float ber);

--- a/TFTSurenoo.cpp
+++ b/TFTSurenoo.cpp
@@ -69,7 +69,7 @@ enum LcdColour {
 
 // This module sometimes ignores display command (too busy?),
 // so supress display refresh
-#define REFRESH_PERIOD		250	// msec
+#define REFRESH_PERIOD		600	// msec
 
 #define STR_CRLF		"\x0D\x0A"
 #define STR_DMR			"DMR"
@@ -367,7 +367,6 @@ void CTFTSurenoo::setLineBuffer(char *buf, const char *text, int maxchar)
 	int i;
 
 	for (i = 0; i < maxchar && text[i]; i++) buf[i] = text[i];
-	for (; i < maxchar; i++) buf[i] = ' ';
 	buf[i] = '\0';
 
 	m_refresh = true;
@@ -390,6 +389,11 @@ void CTFTSurenoo::refreshDisplay(void)
 {
 	if (!m_refresh) return;
 
+	// clear display
+	::snprintf(m_temp, sizeof(m_temp), "BOXF(%d,%d,%d,%d,%d);",
+		   0, 0, X_WIDTH - 1, Y_WIDTH - 1, BG_COLOUR);
+	m_serial->write((unsigned char*)m_temp, ::strlen(m_temp));
+
 	// mode line
 	::snprintf(m_temp, sizeof(m_temp), "DCV%d(%d,%d,'%s',%d);",
 		   MODE_FONT_SIZE, 0, 0, m_lineBuf, MODE_COLOUR);
@@ -397,10 +401,12 @@ void CTFTSurenoo::refreshDisplay(void)
 
 	// status line
 	for (int i = 0; i < STATUS_LINES; i++) {
+		char *p = m_lineBuf + statusLine_offset(i);
+		if (!::strlen(p)) continue;
+
 		::snprintf(m_temp, sizeof(m_temp), "DCV%d(%d,%d,'%s',%d);",
 			   STATUS_FONT_SIZE, 0,
-			   STATUS_MARGIN + STATUS_FONT_SIZE * i,
-			   m_lineBuf + statusLine_offset(i),
+			   STATUS_MARGIN + STATUS_FONT_SIZE * i, p,
 			   (i < INFO_LINES)? INFO_COLOUR : EXT_COLOUR);
 		m_serial->write((unsigned char*)m_temp, ::strlen(m_temp));
 	}

--- a/TFTSurenoo.h
+++ b/TFTSurenoo.h
@@ -46,6 +46,7 @@ protected:
 	virtual void clearDStarInt();
 
 	virtual void writeDMRInt(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type);
+	virtual void writeDMRUserInt(unsigned int slotNo, const std::string& name, std::string& city, std::string &state, std::string &country);
 	virtual void clearDMRInt(unsigned int slotNo);
 
 	virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);


### PR DESCRIPTION
To achieve displaying user information, I added following changes.

* DMRLookup.cpp, DMRLookup.h:
Add loadcsv() to load CSV format-based user database file. If filename ends ".csv" loadcsv() is invoked, otherwise load() handles tab-separated file like DMRIds.dat.
loadcsv() requires comma separated, no quote character (") CSV file like DMR-MARC's user file (https://www.radioid.net/static/user.csv).
1st line defines each fields, 2nd and later line stores user data. These fields are recognized : RADIO_ID, CALLSIGN, FIRST_NAME, LAST_NAME, CITY, STATE, COUNTRY
findUserInfo() is added to query user data. It returns username (fullname), city, state and country from DMR-ID.
findWithName() previously returns callsign and capitalized first name. But this now returns callsign and first name and last name (if available). name is not capitalized.

* DMRSlot.cpp
Call CDMRLookup::findUserInfo() to query user information and pass CDisplay::writeDMRUser(). To make compatibility with unimplemented CXxxxxx::writeDMRUserInt() display driver, current code still passes "callsign and first name (and last name)" (obtained from CDMRLookup::findWithName()) to CDisplay::writeDMR(). It should be fixed with CDMRLookup::find() - CDisplay::writeDMR() and CDMRLookup::findUserInfo() - CDisplay::writeDMRUser() pair in the future.

* Display.cpp, Display.h
Add writeDMRUser() and writeDMRUserInt() to display user info.

* TFTSurenoo.cpp, TFTSurenoo.h
Add writeDMRUserInt() to support user information display and modified display layout to make room for displaying additional information.
Add workaround for "callsign with first name" to writeDMRInt().