### PR TITLE
Tweak how the CW ID behaves on the OLED screen.

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -547,8 +547,8 @@ void COLED::writeCWInt()
 {
     m_display.clearDisplay();
 
-    m_display.setCursor(0,30);
-    m_display.setTextSize(3);
+    m_display.setCursor(10,30);
+    m_display.setTextSize(1);
     m_display.print("CW TX");
 
     m_display.setTextSize(1);
@@ -560,13 +560,16 @@ void COLED::clearCWInt()
 {
     m_display.clearDisplay();
 
-    m_display.setCursor(0,30);
-    m_display.setTextSize(3);
-    m_display.print("Idle");
+    //m_display.setCursor(0,30);
+    //m_display.setTextSize(3);
+    //m_display.print("Idle");
 
-    m_display.setTextSize(1);
+    //m_display.setTextSize(1);
+    //m_display.display();
+    //m_display.startscrollleft(0x02,0x0f);
+
+    OLED_statusbar();
     m_display.display();
-    m_display.startscrollleft(0x02,0x0f);
 }
 
 void COLED::close()


### PR DESCRIPTION
I prefer not to have text on the screen since OLED is susceptible to burn-in.
More specifically, don't leave **-Idle-** on the screen after a CW ID. Also changed the font size of the "CW ID" text and started fiddling with the placement to no avail. This works well (for me) when the Pi-Star screen saver is set to either a blank or logo screen.
