### PR TITLE
WIP: Seeking input - I'm looking to get a consistent CW ID, every {interval} minutes, only when in use

### DIFF
--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -664,6 +664,11 @@ int CMMDVMHost::run()
 			} else if (m_mode == MODE_DSTAR) {
 				m_dstar->writeModem(data, len);
 				m_modeTimer.start();
+				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+					LogDebug("starting CW ID timer - MODE_DSTAR");
+					m_cwIdTimer.start();
+					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("D-Star modem data received when in mode %u", m_mode);
 			}
@@ -691,12 +696,22 @@ int CMMDVMHost::run()
 					if (ret) {
 						m_modem->writeDMRStart(true);
 						m_dmrTXTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_DMR duplex");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					}
 				} else {
 					bool ret = m_dmr->writeModemSlot1(data, len);
 					if (ret) {
 						dmrBeaconDurationTimer.stop();
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_DMR T1");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 						if (m_duplex)
 							m_dmrTXTimer.start();
 					}
@@ -728,12 +743,22 @@ int CMMDVMHost::run()
 					if (ret) {
 						m_modem->writeDMRStart(true);
 						m_dmrTXTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_DMR Duplex T2");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					}
 				} else {
 					bool ret = m_dmr->writeModemSlot2(data, len);
 					if (ret) {
 						dmrBeaconDurationTimer.stop();
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_DMR T2");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 						if (m_duplex)
 							m_dmrTXTimer.start();
 					}
@@ -754,6 +779,11 @@ int CMMDVMHost::run()
 			} else if (m_mode == MODE_YSF) {
 				m_ysf->writeModem(data, len);
 				m_modeTimer.start();
+				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+					LogDebug("starting CW ID timer - MODE_YSF");
+					m_cwIdTimer.start();
+					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("System Fusion modem data received when in mode %u", m_mode);
 			}
@@ -770,6 +800,11 @@ int CMMDVMHost::run()
 			} else if (m_mode == MODE_P25) {
 				m_p25->writeModem(data, len);
 				m_modeTimer.start();
+				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+					LogDebug("starting CW ID timer - MODE_P25");
+					m_cwIdTimer.start();
+					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("P25 modem data received when in mode %u", m_mode);
 			}
@@ -786,6 +821,11 @@ int CMMDVMHost::run()
 			} else if (m_mode == MODE_NXDN) {
 				m_nxdn->writeModem(data, len);
 				m_modeTimer.start();
+				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+					LogDebug("starting CW ID timer - MODE_NXDN");
+					m_cwIdTimer.start();
+					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("NXDN modem data received when in mode %u", m_mode);
 			}
@@ -812,6 +852,11 @@ int CMMDVMHost::run()
 					if (m_mode == MODE_DSTAR) {
 						m_modem->writeDStarData(data, len);
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_DMR T2");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("D-Star data received when in mode %u", m_mode);
 					}
@@ -836,6 +881,11 @@ int CMMDVMHost::run()
 						m_modem->writeDMRData1(data, len);
 						dmrBeaconDurationTimer.stop();
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_DMR T2");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("DMR data received when in mode %u", m_mode);
 					}
@@ -854,6 +904,11 @@ int CMMDVMHost::run()
 						if (m_duplex) {
 							m_modem->writeDMRStart(true);
 							m_dmrTXTimer.start();
+							if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+								LogDebug("starting CW ID timer - MODE_DMR T2");
+								m_cwIdTimer.start();
+								LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+							}
 						}
 						m_modem->writeDMRData2(data, len);
 						dmrBeaconDurationTimer.stop();
@@ -877,6 +932,11 @@ int CMMDVMHost::run()
 					if (m_mode == MODE_YSF) {
 						m_modem->writeYSFData(data, len);
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_YSF");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("System Fusion data received when in mode %u", m_mode);
 					}
@@ -896,6 +956,11 @@ int CMMDVMHost::run()
 					if (m_mode == MODE_P25) {
 						m_modem->writeP25Data(data, len);
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_P25");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("P25 data received when in mode %u", m_mode);
 					}
@@ -915,6 +980,11 @@ int CMMDVMHost::run()
 					if (m_mode == MODE_NXDN) {
 						m_modem->writeNXDNData(data, len);
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_NXDN");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("NXDN data received when in mode %u", m_mode);
 					}
@@ -934,6 +1004,11 @@ int CMMDVMHost::run()
 					if (m_mode == MODE_POCSAG) {
 						m_modem->writePOCSAGData(data, len);
 						m_modeTimer.start();
+						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
+							LogDebug("starting CW ID timer - MODE_POCSAG");
+							m_cwIdTimer.start();
+							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
+						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("POCSAG data received when in mode %u", m_mode);
 					}
@@ -993,12 +1068,14 @@ int CMMDVMHost::run()
 		m_cwIdTimer.clock(ms);
 		if (m_cwIdTimer.isRunning() && m_cwIdTimer.hasExpired()) {
 			if (!m_modem->hasTX()){
-				LogDebug("sending CW ID");
+				LogInfo("sending CW ID");
+				setMode(MODE_IDLE);
 				m_display->writeCW();
 				m_modem->sendCWId(m_cwCallsign);
 
 				m_cwIdTimer.setTimeout(m_cwIdTime);
-				m_cwIdTimer.start();
+				//m_cwIdTimer.start();
+				m_cwIdTimer.stop();
 			}
 		}
 
@@ -1055,6 +1132,11 @@ int CMMDVMHost::run()
 
 		if (ms < 5U)
 			CThread::sleep(5U);
+	}
+
+	// ID one last time in case there's been a transmission since the last ID.
+	if (m_conf.getCWIdEnabled() && m_cwIdTimer.isRunning()) {
+		m_modem->sendCWId(m_callsign);
 	}
 
 	setMode(MODE_QUIT);
@@ -1504,7 +1586,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_DSTAR);
 		m_mode = MODE_DSTAR;
 		m_modeTimer.start();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_DSTAR");
+		//m_cwIdTimer.stop();
 		createLockFile("D-Star");
 		break;
 
@@ -1542,7 +1625,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 		}
 		m_mode = MODE_DMR;
 		m_modeTimer.start();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_DMR");
+		//m_cwIdTimer.stop();
 		createLockFile("DMR");
 		break;
 
@@ -1576,7 +1660,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_YSF);
 		m_mode = MODE_YSF;
 		m_modeTimer.start();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_YSF");
+		//m_cwIdTimer.stop();
 		createLockFile("System Fusion");
 		break;
 
@@ -1610,7 +1695,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_P25);
 		m_mode = MODE_P25;
 		m_modeTimer.start();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_P25");
+		//m_cwIdTimer.stop();
 		createLockFile("P25");
 		break;
 
@@ -1644,7 +1730,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_NXDN);
 		m_mode = MODE_NXDN;
 		m_modeTimer.start();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_NXDN");
+		//m_cwIdTimer.stop();
 		createLockFile("NXDN");
 		break;
 
@@ -1678,7 +1765,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_POCSAG);
 		m_mode = MODE_POCSAG;
 		m_modeTimer.start();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_POCSAG");
+		//m_cwIdTimer.stop();
 		createLockFile("POCSAG");
 		break;
 
@@ -1718,7 +1806,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 		m_display->setLockout();
 		m_mode = MODE_LOCKOUT;
 		m_modeTimer.stop();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_LOCKOUT");
+		//m_cwIdTimer.stop();
 		removeLockFile();
 		break;
 
@@ -1757,7 +1846,8 @@ void CMMDVMHost::setMode(unsigned char mode)
 		m_display->setError("MODEM");
 		m_mode = MODE_ERROR;
 		m_modeTimer.stop();
-		m_cwIdTimer.stop();
+		//LogDebug("stopping CW ID timer - MODE_ERROR");
+		//m_cwIdTimer.stop();
 		removeLockFile();
 		break;
 
@@ -1798,8 +1888,10 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_cwIdTimer.setTimeout(m_cwIdTime);
 			m_cwIdTimer.start();
 		} else {
-			m_cwIdTimer.setTimeout(m_cwIdTime / 4U);
-			m_cwIdTimer.start();
+			if (m_mode != MODE_IDLE) {
+				m_cwIdTimer.setTimeout(m_cwIdTime);
+				//m_cwIdTimer.start();
+			}
 		}
 		m_display->setIdle();
 		if (mode == MODE_QUIT)

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -667,7 +667,6 @@ int CMMDVMHost::run()
 				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 					LogDebug("starting CW ID timer - MODE_DSTAR");
 					m_cwIdTimer.start();
-					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("D-Star modem data received when in mode %u", m_mode);
@@ -699,7 +698,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_DMR duplex");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					}
 				} else {
@@ -710,7 +708,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_DMR T1");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 						if (m_duplex)
 							m_dmrTXTimer.start();
@@ -746,7 +743,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_DMR Duplex T2");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					}
 				} else {
@@ -757,7 +753,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_DMR T2");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 						if (m_duplex)
 							m_dmrTXTimer.start();
@@ -782,7 +777,6 @@ int CMMDVMHost::run()
 				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 					LogDebug("starting CW ID timer - MODE_YSF");
 					m_cwIdTimer.start();
-					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("System Fusion modem data received when in mode %u", m_mode);
@@ -803,7 +797,6 @@ int CMMDVMHost::run()
 				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 					LogDebug("starting CW ID timer - MODE_P25");
 					m_cwIdTimer.start();
-					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("P25 modem data received when in mode %u", m_mode);
@@ -824,7 +817,6 @@ int CMMDVMHost::run()
 				if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 					LogDebug("starting CW ID timer - MODE_NXDN");
 					m_cwIdTimer.start();
-					LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 				}
 			} else if (m_mode != MODE_LOCKOUT) {
 				LogWarning("NXDN modem data received when in mode %u", m_mode);
@@ -855,7 +847,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_DMR T2");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("D-Star data received when in mode %u", m_mode);
@@ -884,7 +875,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_DMR T2");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("DMR data received when in mode %u", m_mode);
@@ -907,7 +897,6 @@ int CMMDVMHost::run()
 							if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 								LogDebug("starting CW ID timer - MODE_DMR T2");
 								m_cwIdTimer.start();
-								LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 							}
 						}
 						m_modem->writeDMRData2(data, len);
@@ -935,7 +924,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_YSF");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("System Fusion data received when in mode %u", m_mode);
@@ -959,7 +947,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_P25");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("P25 data received when in mode %u", m_mode);
@@ -983,7 +970,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_NXDN");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("NXDN data received when in mode %u", m_mode);
@@ -1007,7 +993,6 @@ int CMMDVMHost::run()
 						if (m_conf.getCWIdEnabled() && !m_cwIdTimer.isRunning()) {
 							LogDebug("starting CW ID timer - MODE_POCSAG");
 							m_cwIdTimer.start();
-							LogDebug("CW ID timer remaining: %u", m_cwIdTimer.getRemaining());
 						}
 					} else if (m_mode != MODE_LOCKOUT) {
 						LogWarning("POCSAG data received when in mode %u", m_mode);
@@ -1068,7 +1053,7 @@ int CMMDVMHost::run()
 		m_cwIdTimer.clock(ms);
 		if (m_cwIdTimer.isRunning() && m_cwIdTimer.hasExpired()) {
 			if (!m_modem->hasTX()){
-				LogInfo("sending CW ID");
+				LogMessage("Sending CW ID");
 				setMode(MODE_IDLE);
 				m_display->writeCW();
 				m_modem->sendCWId(m_cwCallsign);
@@ -1586,7 +1571,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_DSTAR);
 		m_mode = MODE_DSTAR;
 		m_modeTimer.start();
-		//LogDebug("stopping CW ID timer - MODE_DSTAR");
 		//m_cwIdTimer.stop();
 		createLockFile("D-Star");
 		break;
@@ -1625,7 +1609,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 		}
 		m_mode = MODE_DMR;
 		m_modeTimer.start();
-		//LogDebug("stopping CW ID timer - MODE_DMR");
 		//m_cwIdTimer.stop();
 		createLockFile("DMR");
 		break;
@@ -1660,7 +1643,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_YSF);
 		m_mode = MODE_YSF;
 		m_modeTimer.start();
-		//LogDebug("stopping CW ID timer - MODE_YSF");
 		//m_cwIdTimer.stop();
 		createLockFile("System Fusion");
 		break;
@@ -1695,7 +1677,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_P25);
 		m_mode = MODE_P25;
 		m_modeTimer.start();
-		//LogDebug("stopping CW ID timer - MODE_P25");
 		//m_cwIdTimer.stop();
 		createLockFile("P25");
 		break;
@@ -1730,7 +1711,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_NXDN);
 		m_mode = MODE_NXDN;
 		m_modeTimer.start();
-		//LogDebug("stopping CW ID timer - MODE_NXDN");
 		//m_cwIdTimer.stop();
 		createLockFile("NXDN");
 		break;
@@ -1765,7 +1745,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_ump->setMode(MODE_POCSAG);
 		m_mode = MODE_POCSAG;
 		m_modeTimer.start();
-		//LogDebug("stopping CW ID timer - MODE_POCSAG");
 		//m_cwIdTimer.stop();
 		createLockFile("POCSAG");
 		break;
@@ -1806,7 +1785,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 		m_display->setLockout();
 		m_mode = MODE_LOCKOUT;
 		m_modeTimer.stop();
-		//LogDebug("stopping CW ID timer - MODE_LOCKOUT");
 		//m_cwIdTimer.stop();
 		removeLockFile();
 		break;
@@ -1846,7 +1824,6 @@ void CMMDVMHost::setMode(unsigned char mode)
 		m_display->setError("MODEM");
 		m_mode = MODE_ERROR;
 		m_modeTimer.stop();
-		//LogDebug("stopping CW ID timer - MODE_ERROR");
 		//m_cwIdTimer.stop();
 		removeLockFile();
 		break;

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -547,8 +547,8 @@ void COLED::writeCWInt()
 {
     m_display.clearDisplay();
 
-    m_display.setCursor(0,30);
-    m_display.setTextSize(3);
+    m_display.setCursor(10,30);
+    m_display.setTextSize(1);
     m_display.print("CW TX");
 
     m_display.setTextSize(1);
@@ -560,13 +560,16 @@ void COLED::clearCWInt()
 {
     m_display.clearDisplay();
 
-    m_display.setCursor(0,30);
-    m_display.setTextSize(3);
-    m_display.print("Idle");
+    //m_display.setCursor(0,30);
+    //m_display.setTextSize(3);
+    //m_display.print("Idle");
 
-    m_display.setTextSize(1);
+    //m_display.setTextSize(1);
+    //m_display.display();
+    //m_display.startscrollleft(0x02,0x0f);
+
+    OLED_statusbar();
     m_display.display();
-    m_display.startscrollleft(0x02,0x0f);
 }
 
 void COLED::close()


### PR DESCRIPTION
This set of mods seems to work, most of the time. I have noticed two problems and I'd like some guidance.
1. At times it switches to CW ID, but without transmitting, when the hotspot is receiving. 
2. Some times the hotspot goes to CW ID but it doesn't transmit even though the channel is clear (no red LED).
I've removed many instances where the CW ID Timer was stopped because that resets the timer and, in the US at least, resetting the timer when restarting isn't acceptable. I toyed with the idea of changing the behaviour of the Timer class to allow stop/start without reset, but haven't convinced myself that's needed yet. 