### PR TITLE
Lookup name on DMR network late entry (2)

### DIFF
--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -1367,8 +1367,9 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 	
 			std::string src = m_lookup->find(srcId);
 			std::string dst = m_lookup->find(dstId);
+			std::string cn  = m_lookup->findWithName(srcId);
 
-			m_display->writeDMR(m_slotNo, src, m_netLC->getFLCO() == FLCO_GROUP, dst, "N");
+			m_display->writeDMR(m_slotNo, cn, m_netLC->getFLCO() == FLCO_GROUP, dst, "N");
 
 			LogMessage("DMR Slot %u, received network late entry from %s to %s%s", m_slotNo, src.c_str(), m_netLC->getFLCO() == FLCO_GROUP ? "TG " : "", dst.c_str());
 		}


### PR DESCRIPTION
There is two cases that shows "received network late entry"

1. dataType == DT_VOICE_PI_HEADER && m_netState != RS_NET_AUDIO
2. dataType == DT_VOICE_SYNC && m_netState == RS_NET_IDLE

case 1 is already treated. this fix is for case 2.