### PR TITLE
TFTSurenoo: Simplify DMR status display

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -447,7 +447,7 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CUMP* ump, CModem* modem)
 			serial = new CSerialController(port, (type == "TFT Serial") ? SERIAL_9600 : SERIAL_115200);
 
 		if (type == "TFT Surenoo")
-			display = new CTFTSurenoo(conf.getCallsign(), dmrid, serial, brightness);
+			display = new CTFTSurenoo(conf.getCallsign(), dmrid, serial, brightness, conf.getDuplex());
 		else
 			display = new CTFTSerial(conf.getCallsign(), dmrid, serial, brightness);
 	} else if (type == "Nextion") {

--- a/TFTSurenoo.h
+++ b/TFTSurenoo.h
@@ -29,7 +29,7 @@
 class CTFTSurenoo : public CDisplay
 {
 public:
-  CTFTSurenoo(const std::string& callsign, unsigned int dmrid, ISerialPort* serial, unsigned int brightness);
+  CTFTSurenoo(const std::string& callsign, unsigned int dmrid, ISerialPort* serial, unsigned int brightness, bool duplex);
   virtual ~CTFTSurenoo();
 
   virtual bool open();
@@ -71,6 +71,7 @@ private:
    ISerialPort*  m_serial;
    unsigned int  m_brightness;
    unsigned char m_mode;
+   bool          m_duplex;
    bool          m_refresh;
    CTimer        m_refreshTimer;
    char*         m_lineBuf;


### PR DESCRIPTION
Old DMR status display takes 4 lines i.e.:

	1 Listening
	(unused line here)
	2 N Callsign
	TGxx

To make room for display area for future development, DMR status display
are changed to 2-lines style like this:

	N Callsign
	TS2 TGxx

And, added three small changes:

	- use statusLine() macro to change layout easily
	- use two -> three colors
		yellow: radio mode (DMR, YSF, etc)
		cyan: main status (callsign, TG/Timeslot)
		dark green: additional information (D* reflector etc) *NEW*
	- rename statusLine_offset() -> statusLineOffset()