### PR TITLE
Expand remote commands to allow sending text as CW

### DIFF
--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -1986,6 +1986,17 @@ void CMMDVMHost::remoteControl()
 				}
 				m_pocsag->sendPage(ric, text);
 			}
+		case RCD_CW:
+                        if (!m_modem->hasTX()){
+                                std::string cwtext;
+                                for (unsigned int i = 0U; i < m_remoteControl->getArgCount(); i++) {
+                                        if (i > 0U)
+                                                cwtext += " ";
+                                        cwtext += m_remoteControl->getArgString(i);
+                                }
+                                m_display->writeCW();
+                                m_modem->sendCWId(cwtext);
+                        }
 		default:
 			break;
 	}

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -1987,6 +1987,7 @@ void CMMDVMHost::remoteControl()
 				m_pocsag->sendPage(ric, text);
 			}
 		case RCD_CW:
+			setMode(MODE_IDLE); // Force the modem to go idle so that we can send the CW text.
                         if (!m_modem->hasTX()){
                                 std::string cwtext;
                                 for (unsigned int i = 0U; i < m_remoteControl->getArgCount(); i++) {

--- a/RemoteControl.cpp
+++ b/RemoteControl.cpp
@@ -26,6 +26,7 @@
 
 const unsigned int SET_MODE_ARGS = 2U;
 const unsigned int PAGE_ARGS = 3U;
+const unsigned int CW_ARGS = 2U;
 
 const unsigned int BUFFER_LENGTH = 100U;
 
@@ -89,7 +90,10 @@ REMOTE_COMMAND CRemoteControl::getCommand()
 		} else if (m_args.at(0U) == "page" && m_args.size() >= PAGE_ARGS) {
 			// Page command is in the form of "page <ric> <message>"
 			m_command = RCD_PAGE;
-		}
+		} else if (m_args.at(0U) == "cw" && m_args.size() >= CW_ARGS) {
+                        // CW command is in the form of "cw <message>"
+                        m_command = RCD_CW;
+                }
 
 		if (m_command == RCD_NONE) {
 			m_args.clear();
@@ -115,6 +119,8 @@ unsigned int CRemoteControl::getArgCount() const
 			return m_args.size() - SET_MODE_ARGS;
 		case RCD_PAGE:
 			return m_args.size() - 1U;
+		case RCD_CW:
+                        return m_args.size() - 1U;
 		default:
 			return 0U;
 	}
@@ -135,6 +141,9 @@ std::string CRemoteControl::getArgString(unsigned int n) const
 		case RCD_PAGE:
 			n += 1U;
 			break;
+		case RCD_CW:
+                        n += 1U;
+                        break;
 		default:
 			return "";
 	}

--- a/RemoteControl.h
+++ b/RemoteControl.h
@@ -33,7 +33,8 @@ enum REMOTE_COMMAND {
 	RCD_MODE_YSF,
 	RCD_MODE_P25,
 	RCD_MODE_NXDN,
-	RCD_PAGE
+	RCD_PAGE,
+        RCD_CW
 };
 
 class CRemoteControl {


### PR DESCRIPTION
The idea here is that any text from the command line can be send as CW, a word of warning, it's setup to force the modem to idle before sending CW, so it is expected to interrupt any on-going transmission to send the CW.

Currently the format of the remote command is "RemoteCommand <port> cw <message>" where message needs to be in upper case.