### PR TITLE
Update RemoteCommand to disable/enable network modes

### DIFF
--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -1997,22 +1997,32 @@ void CMMDVMHost::remoteControl()
 		case RCD_ENABLE_DSTAR:
 			if (m_dstar != NULL && m_dstarEnabled==false)
 				processEnableCommand(m_dstarEnabled, true);
+                        if (m_dstarNetwork != NULL)
+                                m_dstarNetwork->enable(true);
 			break;
 		case RCD_ENABLE_DMR:
 			if (m_dmr != NULL && m_dmrEnabled==false)
 				processEnableCommand(m_dmrEnabled, true);
+                        if (m_dmrNetwork != NULL)
+                                m_dmrNetwork->enable(true);
 			break;
 		case RCD_ENABLE_YSF:
 			if (m_ysf != NULL && m_ysfEnabled==false)
 				processEnableCommand(m_ysfEnabled, true);
+                        if (m_ysfNetwork != NULL)
+                                m_ysfNetwork->enable(true);
 			break;
 		case RCD_ENABLE_P25:
 			if (m_p25 != NULL && m_p25Enabled==false)
 				processEnableCommand(m_p25Enabled, true);
+                       if (m_p25Network != NULL)
+                                m_p25Network->enable(true);
 			break;
 		case RCD_ENABLE_NXDN:
 			if (m_nxdn != NULL && m_nxdnEnabled==false)
 				processEnableCommand(m_nxdnEnabled, true);
+                        if (m_nxdnNetwork != NULL)
+                                m_nxdnNetwork->enable(true);
 			break;
 		case RCD_ENABLE_FM:
 			if (m_fmEnabled==false)
@@ -2021,22 +2031,32 @@ void CMMDVMHost::remoteControl()
 		case RCD_DISABLE_DSTAR:
 			if (m_dstar != NULL && m_dstarEnabled==true)
 				processEnableCommand(m_dstarEnabled, false);
+                        if (m_dstarNetwork != NULL)
+                                m_dstarNetwork->enable(false);
 			break;
 		case RCD_DISABLE_DMR:
 			if (m_dmr != NULL && m_dmrEnabled==true)
 				processEnableCommand(m_dmrEnabled, false);
+                        if (m_dmrNetwork != NULL)
+                                m_dmrNetwork->enable(false);
 			break;
 		case RCD_DISABLE_YSF:
 			if (m_ysf != NULL && m_ysfEnabled==true)
 				processEnableCommand(m_ysfEnabled, false);
+                        if (m_ysfNetwork != NULL)
+                                m_ysfNetwork->enable(false);
 			break;
 		case RCD_DISABLE_P25:
 			if (m_p25 != NULL && m_p25Enabled==true)
 				processEnableCommand(m_p25Enabled, false);
+                        if (m_p25Network != NULL)
+                                m_p25Network->enable(false);
 			break;
 		case RCD_DISABLE_NXDN:
 			if (m_nxdn != NULL && m_nxdnEnabled==true)
 				processEnableCommand(m_nxdnEnabled, false);
+                        if (m_nxdnNetwork != NULL)
+                                m_nxdnNetwork->enable(false);
 			break;
 		case RCD_DISABLE_FM:
 			if (m_fmEnabled == true)


### PR DESCRIPTION
While testing the enable/disable functionality, I noticed that if a mode is disabled while it is currently receiving network data, the rfbuffer will overflow and generate lots of error messages, this stops that by also disabling the network mode.