### PR TITLE
change ScreenLayout definition for Nextion

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -566,7 +566,7 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CUMP* ump, CModem* modem)
                         }
 		} else {
 			SERIAL_SPEED baudrate = SERIAL_9600;
-			if (screenLayout==4U)
+			if (screenLayout&0x0cU)
 				baudrate = SERIAL_115200;
 			
 			LogInfo("    Display baudrate: %u ",baudrate);


### PR DESCRIPTION
to add new feature easily, the definition of ScreenLayout in [Nextion]
has changed like this.

ScreenLayout < 8: compatibile setting for old config file

	0: G4KLX @ 9600bps
	1: (reserved)
	2: ON7LDS @ 9600bps
	3: ON7LDS-DIY @ 9600bps
	4: ON7LDS-DIY @ 115200bps

ScreenLayout >= 8: new world, set the bit to enable each feature

	bit3 (8)	use 115200bps
	bit4 (16)	Display DMR Talker Alias
	bit5 (32)	Colour change when displaying TA
	bit6 (64)	Font size change when displaying long TA text
	bit7 (128)	Display DIY status when MMDVM IDLE

old settings are same as:

	0 -> 0
	2 -> 112 (16+32+64)
	3 -> 144 (16+128)
	4 -> 152 (8+16+128)