### PR TITLE
permit inline comment (2)

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -391,8 +391,16 @@ bool CConf::read()
 	  value[len - 1U] = '\0';
 	  value++;
   } else {
+	  char *p;
+
 	  // if value is not quoted, remove after # (to make comment)
-	  strtok(value, "#");
+	  if ((p = strchr(value, '#')) != NULL)
+		*p = '\0';
+
+	  // remove trailing tab/space
+	  for (p = value + strlen(value) - 1;
+	       p >= value && (*p == '\t' || *p == ' '); p--)
+		*p = '\0';
   }
 
   if (section == SECTION_GENERAL) {


### PR DESCRIPTION
To implement this feature, using strtok() is not enough.

This cannot handle this case:

	Key=#value#comment

it will be `#value` is the contents of Key. And,

	Key=value 	#comment
	(there is a space and a tab between value and #comment)

this will be `value 	` (a space and a tab follows after value).
Sometimes these trailing spaces and tabs makes thing wrong.

Whether in-line comment is used or not, delete trailing space/tab after value.