### PR TITLE
Update files to remove DG-ID and maintain consistency in code

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -155,8 +155,6 @@ m_fusionLowDeviation(false),
 m_fusionRemoteGateway(false),
 m_fusionSelfOnly(false),
 m_fusionTXHang(4U),
-m_fusionDGIdEnabled(false),
-m_fusionDGId(0U),
 m_fusionModeHang(10U),
 m_p25Enabled(false),
 m_p25Id(0U),
@@ -667,10 +665,7 @@ bool CConf::read()
 			m_fusionEnabled = ::atoi(value) == 1;
 		else if (::strcmp(key, "LowDeviation") == 0)
 			m_fusionLowDeviation = ::atoi(value) == 1;
-		else if (::strcmp(key, "DGID") == 0) {
-			m_fusionDGIdEnabled = true;
-			m_fusionDGId        = (unsigned int)::atoi(value);
-		} else if (::strcmp(key, "RemoteGateway") == 0)
+		else if (::strcmp(key, "RemoteGateway") == 0)
 			m_fusionRemoteGateway = ::atoi(value) == 1;
 		else if (::strcmp(key, "SelfOnly") == 0)
 			m_fusionSelfOnly = ::atoi(value) == 1;
@@ -1442,16 +1437,6 @@ unsigned int CConf::getFusionTXHang() const
 bool CConf::getFusionSelfOnly() const
 {
 	return m_fusionSelfOnly;
-}
-
-bool CConf::getFusionDGIdEnabled() const
-{
-	return m_fusionDGIdEnabled;
-}
-
-unsigned char CConf::getFusionDGId() const
-{
-	return m_fusionDGId;
 }
 
 unsigned int CConf::getFusionModeHang() const

--- a/Conf.h
+++ b/Conf.h
@@ -145,8 +145,6 @@ public:
   bool          getFusionRemoteGateway() const;
   bool          getFusionSelfOnly() const;
   unsigned int  getFusionTXHang() const;
-  bool          getFusionDGIdEnabled() const;
-  unsigned char getFusionDGId() const;
   unsigned int  getFusionModeHang() const;
 
   // The P25 section
@@ -421,8 +419,6 @@ private:
   bool          m_fusionRemoteGateway;
   bool          m_fusionSelfOnly;
   unsigned int  m_fusionTXHang;
-  bool          m_fusionDGIdEnabled;
-  unsigned char m_fusionDGId;
   unsigned int  m_fusionModeHang;
 
   bool         m_p25Enabled;

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -117,7 +117,6 @@ Enable=1
 LowDeviation=0
 SelfOnly=0
 TXHang=4
-#DGID=1
 RemoteGateway=0
 # ModeHang=10
 

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -535,8 +535,6 @@ int CMMDVMHost::run()
 		bool remoteGateway  = m_conf.getFusionRemoteGateway();
 		unsigned int txHang = m_conf.getFusionTXHang();
 		bool selfOnly       = m_conf.getFusionSelfOnly();
-		bool dgIdEnabled    = m_conf.getFusionDGIdEnabled();
-		unsigned char dgId  = m_conf.getFusionDGId();
 		m_ysfRFModeHang     = m_conf.getFusionModeHang();
 
 		LogInfo("YSF RF Parameters");
@@ -544,13 +542,9 @@ int CMMDVMHost::run()
 		LogInfo("    Remote Gateway: %s", remoteGateway ? "yes" : "no");
 		LogInfo("    TX Hang: %us", txHang);
 		LogInfo("    Self Only: %s", selfOnly ? "yes" : "no");
-		LogInfo("    DG-ID: %s", dgIdEnabled ? "yes" : "no");
-		if (dgIdEnabled)
-			LogInfo("    DG-ID Value: %u", dgId);
 		LogInfo("    Mode Hang: %us", m_ysfRFModeHang);
 
 		m_ysf = new CYSFControl(m_callsign, selfOnly, m_ysfNetwork, m_display, m_timeout, m_duplex, lowDeviation, remoteGateway, rssi);
-		m_ysf->setDGId(dgIdEnabled, dgId);
 	}
 
 	if (m_p25Enabled) {

--- a/YSFControl.h
+++ b/YSFControl.h
@@ -38,8 +38,6 @@ public:
 	CYSFControl(const std::string& callsign, bool selfOnly, CYSFNetwork* network, CDisplay* display, unsigned int timeout, bool duplex, bool lowDeviation, bool remoteGateway, CRSSIInterpolator* rssiMapper);
 	~CYSFControl();
 
-	void setDGId(bool on, unsigned char value);
-
 	bool writeModem(unsigned char* data, unsigned int len);
 
 	unsigned int readModem(unsigned char* data);
@@ -59,8 +57,6 @@ private:
 	bool                       m_duplex;
 	bool                       m_lowDeviation;
 	bool                       m_remoteGateway;
-	bool                       m_dgIdEnabled;
-	unsigned char              m_dgIdValue;
 	CRingBuffer<unsigned char> m_queue;
 	RPT_RF_STATE               m_rfState;
 	RPT_NET_STATE              m_netState;


### PR DESCRIPTION
These changes in files are for the program to compile so we removed dg-id option references in code and MMDVM.ini file.