### PR TITLE
OLED: fix build after f070410f7 and c7fbeecc5

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -434,7 +434,7 @@ void COLED::clearDMRInt(unsigned int slotNo)
     m_display.display();
 }
 
-void COLED::writeFusionInt(const char* source, const char* dest, const char* type, const char* origin)
+void COLED::writeFusionInt(const char* source, const char* dest, unsigned char dgid, const char* type, const char* origin)
 {
     m_mode = MODE_YSF;
 

--- a/OLED.h
+++ b/OLED.h
@@ -58,7 +58,7 @@ public:
   virtual void writeDMRInt(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type);
   virtual void clearDMRInt(unsigned int slotNo);
 
-  virtual void writeFusionInt(const char* source, const char* dest, const char* type, const char* origin);
+  virtual void writeFusionInt(const char* source, const char* dest, unsigned char dgid, const char* type, const char* origin);
   virtual void clearFusionInt();
 
   virtual void writeP25Int(const char* source, bool group, unsigned int dest, const char* type);


### PR DESCRIPTION
```
============================
Display.cpp: In static member function 'static CDisplay* CDisplay::createDisplay(const CConf&, CUMP*, CModem*)':
Display.cpp:645:128: error: invalid new-expression of abstract class type 'COLED'
  645 |   display = new COLED(type, brightness, invert, scroll, rotate, logosaver, conf.getDMRNetworkSlot1(), conf.getDMRNetworkSlot2());
      |                                                                                                                                ^
In file included from Display.cpp:39:
OLED.h:40:7: note:   because the following virtual functions are pure within 'COLED':
   40 | class COLED : public CDisplay
      |       ^~~~~
In file included from Display.cpp:19:
Display.h:105:15: note: 	'virtual void CDisplay::writeFusionInt(const char*, const char*, unsigned char, const char*, const char*)'
  105 |  virtual void writeFusionInt(const char* source, const char* dest, unsigned char dgid, const char* type, const char* origin) = 0;
============================
```