### PR TITLE
change tx and rx frequency display precision (to reflect ini file significant figures)

### DIFF
--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -121,8 +121,8 @@ bool CNextion::open()
 	sendCommand("bkcmd=0");
 	sendCommandAction(0U);
 	
-	m_fl_txFrequency = float(m_txFrequency) / 1000000.0F;
-	m_fl_rxFrequency = float(m_rxFrequency) / 1000000.0F;
+	m_fl_txFrequency = double(m_txFrequency) / 1000000.0F;
+	m_fl_rxFrequency = double(m_rxFrequency) / 1000000.0F;
 	
 	setIdle();
 
@@ -152,11 +152,11 @@ void CNextion::setIdleInt()
 		sendCommand(command);
 		sendCommandAction(17U);
 
-		::sprintf(command, "t30.txt=\"%3.4f\"",m_fl_rxFrequency);  // RX freq
+		::sprintf(command, "t30.txt=\"%3.6f\"",m_fl_rxFrequency);  // RX freq
 		sendCommand(command);
 		sendCommandAction(20U);
 		
-		::sprintf(command, "t32.txt=\"%3.4f\"",m_fl_txFrequency);  // TX freq
+		::sprintf(command, "t32.txt=\"%3.6f\"",m_fl_txFrequency);  // TX freq
 		sendCommand(command);
 		sendCommandAction(21U);
 	

--- a/Nextion.h
+++ b/Nextion.h
@@ -100,8 +100,8 @@ private:
   unsigned int  m_berCount2;
   unsigned int  m_txFrequency;
   unsigned int  m_rxFrequency;
-  float         m_fl_txFrequency;
-  float         m_fl_rxFrequency;
+  double        m_fl_txFrequency;
+  double        m_fl_rxFrequency;
   bool          m_displayTempInF;
   std::string   m_location;
   


### PR DESCRIPTION
The ini file frequencies are in Hz and have 9 significant figures
Some people use 6.25KHz spacing (f.e. vk7hse).

This PR changes the MHz freq. caculation to double to achieve enough significant figures to show 6 digits after the decimal point (and does show them)