### PR TITLE
UDPSocket renewal

### DIFF
--- a/DMRNetwork.cpp
+++ b/DMRNetwork.cpp
@@ -128,7 +128,7 @@ bool CDMRNetwork::open()
 {
 	LogMessage("DMR, Opening DMR Network");
 
-	if (CUDPSocket::isnone(m_address))
+	if (CUDPSocket::isNone(m_address))
 		CUDPSocket::lookup(m_addressStr, m_port, m_address, m_addrlen);
 
 	m_status = WAITING_CONNECT;

--- a/DStarNetwork.cpp
+++ b/DStarNetwork.cpp
@@ -65,7 +65,7 @@ bool CDStarNetwork::open()
 {
 	LogMessage("Opening D-Star network connection");
 
-	if (CUDPSocket::isnone(m_address))
+	if (CUDPSocket::isNone(m_address))
 		return false;
 
 	m_pollTimer.start();

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LIBS    = -lpthread
 #CFLAGS  = -g -O3 -Wall -DUSE_GPSD -std=c++0x -pthread
 #LIBS    = -lpthread -lgps
 
+CFLAGS += -DHAVE_LOG_H
 LDFLAGS = -g
 
 OBJECTS = \

--- a/NXDNIcomNetwork.cpp
+++ b/NXDNIcomNetwork.cpp
@@ -50,7 +50,7 @@ bool CNXDNIcomNetwork::open()
 {
 	LogMessage("Opening NXDN network connection");
 
-	if (CUDPSocket::isnone(m_address))
+	if (CUDPSocket::isNone(m_address))
 		return false;
 
 	return m_socket.open();

--- a/NXDNKenwoodNetwork.cpp
+++ b/NXDNKenwoodNetwork.cpp
@@ -82,8 +82,8 @@ bool CNXDNKenwoodNetwork::open()
 {
 	LogMessage("Opening Kenwood connection");
 
-	if (CUDPSocket::isnone(m_rtpaddress) ||
-	    CUDPSocket::isnone(m_rtcpaddress))
+	if (CUDPSocket::isNone(m_rtpaddress) ||
+	    CUDPSocket::isNone(m_rtcpaddress))
 		return false;
 
 	if (!m_rtcpSocket.open())
@@ -766,7 +766,7 @@ unsigned int CNXDNKenwoodNetwork::readRTP(unsigned char* data)
 	sockaddr_storage address;
 	unsigned int addrlen;
 	int length = m_rtpSocket.read(buffer, BUFFER_LENGTH, address, addrlen);
-	if (length <= 0 || !CUDPSocket::match_addr(m_rtpaddress, address))
+	if (length <= 0 || !CUDPSocket::match(m_rtpaddress, address, IMT_ADDRESS_ONLY))
 		return 0U;
 
 	if (!m_enabled)
@@ -789,7 +789,7 @@ unsigned int CNXDNKenwoodNetwork::readRTCP(unsigned char* data)
 	sockaddr_storage address;
 	unsigned int addrlen;
 	int length = m_rtcpSocket.read(buffer, BUFFER_LENGTH, address, addrlen);
-	if (length <= 0 || !CUDPSocket::match_addr(m_rtcpaddress, address))
+	if (length <= 0 || !CUDPSocket::match(m_rtcpaddress, address, IMT_ADDRESS_ONLY))
 		return 0U;
 
 	if (!m_enabled)

--- a/P25Network.cpp
+++ b/P25Network.cpp
@@ -107,7 +107,7 @@ bool CP25Network::open()
 {
 	LogMessage("Opening P25 network connection");
 
-	if (CUDPSocket::isnone(m_address))
+	if (CUDPSocket::isNone(m_address))
 		return false;
 
 	return m_socket.open(m_address.ss_family);

--- a/POCSAGNetwork.cpp
+++ b/POCSAGNetwork.cpp
@@ -47,7 +47,7 @@ bool CPOCSAGNetwork::open()
 {
 	LogMessage("Opening POCSAG network connection");
 
-	if (CUDPSocket::isnone(m_address))
+	if (CUDPSocket::isNone(m_address))
 		return false;
 
 	return m_socket.open();

--- a/UDPSocket.cpp
+++ b/UDPSocket.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2006-2016,2018,2020 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2006-2016,2020 by Jonathan Naylor G4KLX
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -57,11 +57,6 @@ CUDPSocket::CUDPSocket(unsigned int port)
 	CUDPSocket("", port);
 }
 
-CUDPSocket::CUDPSocket()
-{
-	CUDPSocket("", 0U);
-}
-
 CUDPSocket::~CUDPSocket()
 {
 #if defined(_WIN32) || defined(_WIN64)
@@ -69,28 +64,26 @@ CUDPSocket::~CUDPSocket()
 #endif
 }
 
-int CUDPSocket::lookup(const std::string& hostname, unsigned int port, sockaddr_storage &addr, unsigned int &address_length)
+int CUDPSocket::lookup(const std::string& hostname, unsigned int port, sockaddr_storage& addr, unsigned int& address_length)
 {
 	struct addrinfo hints;
-
 	::memset(&hints, 0, sizeof(hints));
 
 	return lookup(hostname, port, addr, address_length, hints);
 }
 
-int CUDPSocket::lookup(const std::string& hostname, unsigned int port, sockaddr_storage &addr, unsigned int &address_length, struct addrinfo &hints)
+int CUDPSocket::lookup(const std::string& hostname, unsigned int port, sockaddr_storage& addr, unsigned int& address_length, struct addrinfo& hints)
 {
-	int err;
 	std::string portstr = std::to_string(port);
 	struct addrinfo *res;
 
 	/* port is always digits, no needs to lookup service */
 	hints.ai_flags |= AI_NUMERICSERV;
 
-	err = getaddrinfo(hostname.empty() ? NULL : hostname.c_str(), portstr.c_str(), &hints, &res);
-	if (err) {
-		sockaddr_in *paddr = (sockaddr_in *)&addr;
-		::memset(paddr, 0, address_length = sizeof(sockaddr_in));
+	int err = getaddrinfo(hostname.empty() ? NULL : hostname.c_str(), portstr.c_str(), &hints, &res);
+	if (err != 0) {
+		sockaddr_in* paddr = (sockaddr_in*)&addr;
+		::memset(paddr, 0x00U, address_length = sizeof(sockaddr_in));
 		paddr->sin_family = AF_INET;
 		paddr->sin_port = htons(port);
 		paddr->sin_addr.s_addr = htonl(INADDR_NONE);
@@ -101,90 +94,85 @@ int CUDPSocket::lookup(const std::string& hostname, unsigned int port, sockaddr_
 	::memcpy(&addr, res->ai_addr, address_length = res->ai_addrlen);
 
 	freeaddrinfo(res);
+
 	return 0;
 }
 
-bool CUDPSocket::match(const sockaddr_storage &addr1, const sockaddr_storage &addr2)
+bool CUDPSocket::match(const sockaddr_storage& addr1, const sockaddr_storage& addr2, IPMATCHTYPE type)
 {
 	if (addr1.ss_family != addr2.ss_family)
 		return false;
 
-	switch (addr1.ss_family) {
-	case AF_INET:
-		struct sockaddr_in *in_1, *in_2;
-		in_1 = (struct sockaddr_in *)&addr1;
-		in_2 = (struct sockaddr_in *)&addr2;
-		return ( (in_1->sin_addr.s_addr == in_2->sin_addr.s_addr) &&
-			 (in_1->sin_port == in_2->sin_port) );
-	case AF_INET6:
-		struct sockaddr_in6 *in6_1, *in6_2;
-		in6_1 = (struct sockaddr_in6 *)&addr1;
-		in6_2 = (struct sockaddr_in6 *)&addr2;
-		return ( IN6_ARE_ADDR_EQUAL(&in6_1->sin6_addr, &in6_2->sin6_addr) &&
-			 (in6_1->sin6_port == in6_2->sin6_port) );
-	default:
+	if (type == IMT_ADDRESS_AND_PORT) {
+		switch (addr1.ss_family) {
+		case AF_INET:
+			struct sockaddr_in *in_1, *in_2;
+			in_1 = (struct sockaddr_in*)&addr1;
+			in_2 = (struct sockaddr_in*)&addr2;
+			return (in_1->sin_addr.s_addr == in_2->sin_addr.s_addr) && (in_1->sin_port == in_2->sin_port);
+		case AF_INET6:
+			struct sockaddr_in6 *in6_1, *in6_2;
+			in6_1 = (struct sockaddr_in6*)&addr1;
+			in6_2 = (struct sockaddr_in6*)&addr2;
+			return IN6_ARE_ADDR_EQUAL(&in6_1->sin6_addr, &in6_2->sin6_addr) && (in6_1->sin6_port == in6_2->sin6_port);
+		default:
+			return false;
+		}
+	} else if (type == IMT_ADDRESS_ONLY) {
+		switch (addr1.ss_family) {
+		case AF_INET:
+			struct sockaddr_in *in_1, *in_2;
+			in_1 = (struct sockaddr_in*)&addr1;
+			in_2 = (struct sockaddr_in*)&addr2;
+			return in_1->sin_addr.s_addr == in_2->sin_addr.s_addr;
+		case AF_INET6:
+			struct sockaddr_in6 *in6_1, *in6_2;
+			in6_1 = (struct sockaddr_in6*)&addr1;
+			in6_2 = (struct sockaddr_in6*)&addr2;
+			return IN6_ARE_ADDR_EQUAL(&in6_1->sin6_addr, &in6_2->sin6_addr);
+		default:
+			return false;
+		}
+	} else {
 		return false;
 	}
 }
 
-bool CUDPSocket::match_addr(const sockaddr_storage &addr1, const sockaddr_storage &addr2)
-{
-	if (addr1.ss_family != addr2.ss_family)
-		return false;
-
-	switch (addr1.ss_family) {
-	case AF_INET:
-		struct sockaddr_in *in_1, *in_2;
-		in_1 = (struct sockaddr_in *)&addr1;
-		in_2 = (struct sockaddr_in *)&addr2;
-		return (in_1->sin_addr.s_addr == in_2->sin_addr.s_addr);
-	case AF_INET6:
-		struct sockaddr_in6 *in6_1, *in6_2;
-		in6_1 = (struct sockaddr_in6 *)&addr1;
-		in6_2 = (struct sockaddr_in6 *)&addr2;
-		return IN6_ARE_ADDR_EQUAL(&in6_1->sin6_addr, &in6_2->sin6_addr);
-	default:
-		return false;
-	}
-}
-
-bool CUDPSocket::isnone(const sockaddr_storage &addr)
+bool CUDPSocket::isNone(const sockaddr_storage& addr)
 {
 	struct sockaddr_in *in = (struct sockaddr_in *)&addr;
 
-	return ( (addr.ss_family == AF_INET) &&
-		 (in->sin_addr.s_addr == htonl(INADDR_NONE)) );
+	return ((addr.ss_family == AF_INET) && (in->sin_addr.s_addr == htonl(INADDR_NONE)));
 }
 
-bool CUDPSocket::open()
+bool CUDPSocket::open(const sockaddr_storage& address)
 {
-	return open(0, AF_UNSPEC, m_address[0], m_port[0]);
+	return open(address.ss_family);
 }
 
-bool CUDPSocket::open(const unsigned int af)
+bool CUDPSocket::open(unsigned int af)
 {
 	return open(0, af, m_address[0], m_port[0]);
 }
 
 bool CUDPSocket::open(const unsigned int index, const unsigned int af, const std::string& address, const unsigned int port)
 {
-	int err, fd;
 	sockaddr_storage addr;
 	unsigned int addrlen;
 	struct addrinfo hints;
 
 	::memset(&hints, 0, sizeof(hints));
-	hints.ai_flags = AI_PASSIVE;
+	hints.ai_flags  = AI_PASSIVE;
 	hints.ai_family = af;
 
 	/* to determine protocol family, call lookup() first. */
-	err = lookup(address, port, addr, addrlen, hints);
-	if (err) {
+	int err = lookup(address, port, addr, addrlen, hints);
+	if (err != 0) {
 		LogError("The local address is invalid - %s", address.c_str());
 		return false;
 	}
 
-	fd = ::socket(addr.ss_family, SOCK_DGRAM, 0);
+	int fd = ::socket(addr.ss_family, SOCK_DGRAM, 0);
 	if (fd < 0) {
 #if defined(_WIN32) || defined(_WIN64)
 		LogError("Cannot create the UDP socket, err: %lu", ::GetLastError());

--- a/UDPSocket.h
+++ b/UDPSocket.h
@@ -40,15 +40,19 @@
 #define UDP_SOCKET_MAX	1
 #endif
 
+enum IPMATCHTYPE {
+	IMT_ADDRESS_AND_PORT,
+	IMT_ADDRESS_ONLY
+};
+
 class CUDPSocket {
 public:
 	CUDPSocket(const std::string& address, unsigned int port = 0U);
 	CUDPSocket(unsigned int port = 0U);
-	CUDPSocket();
 	~CUDPSocket();
 
-	bool open();
-	bool open(const unsigned int af);
+	bool open(unsigned int af = AF_UNSPEC);
+	bool open(const sockaddr_storage& address);
 	bool open(const unsigned int index, const unsigned int af, const std::string& address, const unsigned int port);
 
 	int  read(unsigned char* buffer, unsigned int length, sockaddr_storage& address, unsigned int &address_length);
@@ -57,11 +61,11 @@ public:
 	void close();
 	void close(const unsigned int index);
 
-	static int lookup(const std::string& hostName, unsigned int port, sockaddr_storage &address, unsigned int &address_length);
-	static int lookup(const std::string& hostName, unsigned int port, sockaddr_storage &address, unsigned int &address_length, struct addrinfo &hints);
-	static bool match(const sockaddr_storage &addr1, const sockaddr_storage &addr2);
-	static bool match_addr(const sockaddr_storage &addr1, const sockaddr_storage &addr2);
-	static bool isnone(const sockaddr_storage &addr);
+	static int lookup(const std::string& hostName, unsigned int port, sockaddr_storage& address, unsigned int& address_length);
+	static int lookup(const std::string& hostName, unsigned int port, sockaddr_storage& address, unsigned int& address_length, struct addrinfo& hints);
+	static bool match(const sockaddr_storage& addr1, const sockaddr_storage& addr2, IPMATCHTYPE type = IMT_ADDRESS_AND_PORT);
+
+	static bool isNone(const sockaddr_storage& addr);
 
 private:
 	std::string    m_address[UDP_SOCKET_MAX];

--- a/UDPSocket.h
+++ b/UDPSocket.h
@@ -68,6 +68,8 @@ public:
 	static bool isNone(const sockaddr_storage& addr);
 
 private:
+	std::string    m_address_save;
+	unsigned short m_port_save;
 	std::string    m_address[UDP_SOCKET_MAX];
 	unsigned short m_port[UDP_SOCKET_MAX];
 	unsigned int   m_af[UDP_SOCKET_MAX];

--- a/UDPSocket.h
+++ b/UDPSocket.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2009-2011,2013,2015,2016 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2009-2011,2013,2015,2016,2020 by Jonathan Naylor G4KLX
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <poll.h>
 #include <unistd.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -35,19 +36,26 @@
 #include <ws2tcpip.h>
 #endif
 
+#if !defined(UDP_SOCKET_MAX)
+#define UDP_SOCKET_MAX	1
+#endif
+
 class CUDPSocket {
 public:
 	CUDPSocket(const std::string& address, unsigned int port = 0U);
 	CUDPSocket(unsigned int port = 0U);
+	CUDPSocket();
 	~CUDPSocket();
 
 	bool open();
 	bool open(const unsigned int af);
+	bool open(const unsigned int index, const unsigned int af, const std::string& address, const unsigned int port);
 
 	int  read(unsigned char* buffer, unsigned int length, sockaddr_storage& address, unsigned int &address_length);
 	bool write(const unsigned char* buffer, unsigned int length, const sockaddr_storage& address, unsigned int address_length);
 
 	void close();
+	void close(const unsigned int index);
 
 	static int lookup(const std::string& hostName, unsigned int port, sockaddr_storage &address, unsigned int &address_length);
 	static int lookup(const std::string& hostName, unsigned int port, sockaddr_storage &address, unsigned int &address_length, struct addrinfo &hints);
@@ -56,9 +64,11 @@ public:
 	static bool isnone(const sockaddr_storage &addr);
 
 private:
-	std::string    m_address;
-	unsigned short m_port;
-	int            m_fd;
+	std::string    m_address[UDP_SOCKET_MAX];
+	unsigned short m_port[UDP_SOCKET_MAX];
+	unsigned int   m_af[UDP_SOCKET_MAX];
+	int            m_fd[UDP_SOCKET_MAX];
+	unsigned int   m_counter;
 };
 
 #endif

--- a/YSFNetwork.cpp
+++ b/YSFNetwork.cpp
@@ -57,7 +57,7 @@ bool CYSFNetwork::open()
 {
 	LogMessage("Opening YSF network connection");
 
-	if (CUDPSocket::isnone(m_address))
+	if (CUDPSocket::isNone(m_address))
 		return false;
 
 	m_pollTimer.start();


### PR DESCRIPTION
Currently there is six variations of (IPv4) UDPSocket.cpp.

- FMClients, NXDNClients, P25Clients, YSFClients(YSFParrot)
	use ::fprintf() for logging

- YSFClients(YSFReflector)
	use LogError() and LogInfo() for logging
	special open(string &bindaddr) function

- YSFClients(YSFGateway), DAPNETGateway
	use LogError() and LogInfo() for logging

- P25Clients, DMRGateway
	use LogError() for logging
	no LogInfo("Opening UDP port on") message

- NXDNClients
	use LogError() for logging
	no LogInfo("Opening UDP port on") message
	add #include <ifaddrs.h>

- MMDVMHost
	use LogError() for logging
	no LogInfo("Opening UDP port on") message
	no assert(!address.empty()) at constructor

to avoid explosion, commonized them.

	switch ::fprintf()/LogError by #define HAVE_LOG_H
	always display LogInfo("Opening UDP port on") message
	delete #include <ifaddrs.h>, this is not needed
	no assert(!address.empty()) at constructor

and to support YSFReflector, add multiple socket support.
default is #define UDP_SOCKET_MAX 1 so normally this feature is disabled.

added these functions.

	CUDPSocket()	(constructor without any parameters)
	open(index, af, addr, port)
	close(index)

CUDPSocket() means CUDPSocket(address = "", port = 0)
index selects socket, address and port is defined at open.

to have compatibility for old codes, these function works as

	CUDPSocket(addr, port)	store addr and port to index #0
	CUDPSocket(port)	store addr = "" and port to index #0
	open()		open with addr and port of index #0, AF_UNSPEC
	open(af)	open with addr and port of index #0, specified af
	close()		close *all* sockets

read/write operation is for all opened sockets.