### PR TITLE
Makefile.Pi.OLED revised

### DIFF
--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -1,15 +1,15 @@
-# This makefile is for use with the Raspberry Pi when using an OLED display. The wiringpi library is needed.
+# This makefile is for use with the Raspberry Pi when using an OLED display. The wiringpi library is not needed.
 
-CC      = gcc
-CXX     = g++
+CC      = cc
+CXX     = c++
 
 # Use the following CFLAGS and LIBS if you don't want to use gpsd.
 CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -DOLED -I/usr/local/include
-LIBS    = -lArduiPi_OLED -lwiringPi -lpthread
+LIBS    = -lArduiPi_OLED -lpthread
 
 # Use the following CFLAGS and LIBS if you do want to use gpsd.
 #CFLAGS  = -g -O3 -Wall -DUSE_GPSD -std=c++0x -pthread -DOLED -I/usr/local/include
-#LIBS    = -lArduiPi_OLED -lwiringPi -lpthread -lgps
+#LIBS    = -lArduiPi_OLED -lpthread -lgps
 
 LDFLAGS = -g -L/usr/local/lib
 


### PR DESCRIPTION
- use system default compiler (cc/c++) instead of gcc/g++
- no need to link wiringPi library, remove -lwiringPi