### PR TITLE
fix scroll direction

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -242,7 +242,7 @@ void COLED::setIdleInt()
 
 //    m_display.setTextSize(1);
     if (m_displayScroll && m_displayLogoScreensaver)
-        m_display.startscrolldiagright(0x00,0x0f);  //the MMDVM logo scrolls the whole screen
+        m_display.startscrolldiagleft(0x00,0x0f);  //the MMDVM logo scrolls the whole screen
     m_display.display();
 
     unsigned char info[100U];
@@ -610,7 +610,7 @@ void COLED::writeCWInt()
     m_display.setTextSize(1);
     m_display.display();
     if (m_displayScroll)
-        m_display.startscrollright(0x02,0x0f);
+        m_display.startscrollleft(0x02,0x0f);
 }
 
 void COLED::clearCWInt()
@@ -632,7 +632,7 @@ void COLED::close()
     m_display.clearDisplay();
     m_display.fillRect(0, 0, m_display.width(), 16, BLACK);
     if (m_displayScroll)
-        m_display.startscrollright(0x00,0x01);
+        m_display.startscrollleft(0x00,0x01);
     m_display.setCursor(0,00);
     m_display.setTextSize(2);
     m_display.print("-CLOSE-");
@@ -664,5 +664,5 @@ void COLED::OLED_statusbar()
         m_display.drawBitmap(0, 0, logo_glcd_bmp, 128, 16, WHITE);
 
     if (m_displayScroll)
-        m_display.startscrollright(0x00,0x01);
+        m_display.startscrollleft(0x00,0x01);
 }


### PR DESCRIPTION
all messages except clearCWInt(), scroll direction is inverted.
almost all languages are written from left to right,
so scrolling direction should be "display new right-side characters".