### PR TITLE
NetBSD support

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -119,7 +119,7 @@ void Log(unsigned int level, const char* fmt, ...)
 
 	struct tm* tm = ::gmtime(&now.tv_sec);
 
-	::sprintf(buffer, "%c: %04d-%02d-%02d %02d:%02d:%02d.%03lu ", LEVELS[level], tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, now.tv_usec / 1000U);
+	::sprintf(buffer, "%c: %04d-%02d-%02d %02d:%02d:%02d.%03u ", LEVELS[level], tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, (unsigned int)now.tv_usec / 1000U);
 #endif
 
 	va_list vl;

--- a/Makefile.Pi.OLED
+++ b/Makefile.Pi.OLED
@@ -1,15 +1,18 @@
-# This makefile is for use with the Raspberry Pi when using an OLED display. The wiringpi library is needed.
+# This makefile is for use with the Raspberry Pi when using an OLED display. The wiringpi library is not needed.
 
-CC      = gcc
-CXX     = g++
+CC      = cc
+CXX     = c++
 
 # Use the following CFLAGS and LIBS if you don't want to use gpsd.
 CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -DOLED -I/usr/local/include
-LIBS    = -lArduiPi_OLED -lwiringPi -lpthread
+LIBS    = -lArduiPi_OLED -lpthread
 
 # Use the following CFLAGS and LIBS if you do want to use gpsd.
 #CFLAGS  = -g -O3 -Wall -DUSE_GPSD -std=c++0x -pthread -DOLED -I/usr/local/include
-#LIBS    = -lArduiPi_OLED -lwiringPi -lpthread -lgps
+#LIBS    = -lArduiPi_OLED -lpthread -lgps
+
+# If you use NetBSD, add following CFLAGS
+#CFLAGS += -L/usr/local/lib -Wl,-rpath=/usr/local/lib
 
 LDFLAGS = -g -L/usr/local/lib
 

--- a/Thread.cpp
+++ b/Thread.cpp
@@ -95,21 +95,12 @@ void* CThread::helper(void* arg)
 
 void CThread::sleep(unsigned int ms)
 {
-#if defined(__NetBSD__)
-  unsigned int s = ms / 1000;
-  useconds_t us = ms * 1000;
+  struct timespec ts;
 
-  /* value for usleep() should be less than 1,000,000 */
-  if (s)
-    ::sleep(s);
-  if (us)
-    ::usleep(us);
-#else
+  ts.tv_sec = ms / 1000;
+  ts.tv_nsec = (ms % 1000) * 1000000;
 
-  /* other systems can accept larger value */
-  ::usleep(ms * 1000);
-
-#endif
+  ::nanosleep(&ts, NULL);
 }
 
 #endif

--- a/Thread.cpp
+++ b/Thread.cpp
@@ -95,7 +95,14 @@ void* CThread::helper(void* arg)
 
 void CThread::sleep(unsigned int ms)
 {
-	::usleep(ms * 1000);
+  unsigned int s = ms / 1000;
+  useconds_t us = ms * 1000;
+
+  /* value for usleep() should be less than 1,000,000 */
+  if (s)
+    ::sleep(s);
+  if (us)
+    ::usleep(us);
 }
 
 #endif

--- a/Thread.cpp
+++ b/Thread.cpp
@@ -95,6 +95,7 @@ void* CThread::helper(void* arg)
 
 void CThread::sleep(unsigned int ms)
 {
+#if defined(__NetBSD__)
   unsigned int s = ms / 1000;
   useconds_t us = ms * 1000;
 
@@ -103,6 +104,12 @@ void CThread::sleep(unsigned int ms)
     ::sleep(s);
   if (us)
     ::usleep(us);
+#else
+
+  /* other systems can accept larger value */
+  ::usleep(ms * 1000);
+
+#endif
 }
 
 #endif


### PR DESCRIPTION
different from other systems:
- the value for usleep() should be less than 1,000,000
- struct timeval tv_usec is 32bit (not 64bit)
so need treatment for them.