### PR TITLE
CNetworkInfo::getNetworkInterface() OpenBSD/NetBSD support

### DIFF
--- a/NetworkInfo.cpp
+++ b/NetworkInfo.cpp
@@ -172,12 +172,13 @@ void CNetworkInfo::getNetworkInterface(unsigned char* info)
 			if (family == AF_INET) {
 				::sprintf(interfacelist[ifnr], "%s:%s", ifa->ifa_name, host);
 				LogInfo("    IPv4: %s", interfacelist[ifnr]);
+				ifnr++;
 			} else {
 				::sprintf(interfacelist[ifnr], "%s:%s", ifa->ifa_name, host);
 				LogInfo("    IPv6: %s", interfacelist[ifnr]);
+				// due to default routing is for IPv4, other
+				// protocols are not candidate to display.
 			}
-
-			ifnr++;
 		}
 	}
 


### PR DESCRIPTION
add OpenBSD/NetBSD support code to getNetworkInterface().
and the result of that function is limited to IPv4 due to referring routing table is for IPv4.