### PR TITLE
Introducing RotateLog configuration option that allows disabling timestamps on the logfiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ RemoteCommand
 *.user
 *.VC.db
 .vs
+.vscode
 *.ambe
 GitVersion.h

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -82,6 +82,7 @@ m_logDisplayLevel(0U),
 m_logFileLevel(0U),
 m_logFilePath(),
 m_logFileRoot(),
+m_logRotateLogs(1U),
 m_cwIdEnabled(false),
 m_cwIdTime(10U),
 m_cwIdCallsign(),
@@ -453,6 +454,8 @@ bool CConf::read()
 			m_logFileLevel = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "DisplayLevel") == 0)
 			m_logDisplayLevel = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "RotateLogs") == 0)
+			m_logRotateLogs = (unsigned int)::atoi(value);
 	} else if (section == SECTION_CWID) {
 		if (::strcmp(key, "Enable") == 0)
 			m_cwIdEnabled = ::atoi(value) == 1;
@@ -1072,6 +1075,11 @@ std::string CConf::getLogFilePath() const
 std::string CConf::getLogFileRoot() const
 {
 	return m_logFileRoot;
+}
+
+unsigned int CConf::getLogRotateLogs() const
+{
+	return m_logRotateLogs;
 }
 
 bool CConf::getCWIdEnabled() const

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -82,7 +82,7 @@ m_logDisplayLevel(0U),
 m_logFileLevel(0U),
 m_logFilePath(),
 m_logFileRoot(),
-m_logRotateLogs(1U),
+m_logTimestampLogs(1U),
 m_cwIdEnabled(false),
 m_cwIdTime(10U),
 m_cwIdCallsign(),
@@ -454,8 +454,8 @@ bool CConf::read()
 			m_logFileLevel = (unsigned int)::atoi(value);
 		else if (::strcmp(key, "DisplayLevel") == 0)
 			m_logDisplayLevel = (unsigned int)::atoi(value);
-		else if (::strcmp(key, "RotateLogs") == 0)
-			m_logRotateLogs = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "TimestampLogs") == 0)
+			m_logTimestampLogs = (unsigned int)::atoi(value);
 	} else if (section == SECTION_CWID) {
 		if (::strcmp(key, "Enable") == 0)
 			m_cwIdEnabled = ::atoi(value) == 1;
@@ -1077,9 +1077,9 @@ std::string CConf::getLogFileRoot() const
 	return m_logFileRoot;
 }
 
-unsigned int CConf::getLogRotateLogs() const
+unsigned int CConf::getLogTimestampLogs() const
 {
-	return m_logRotateLogs;
+	return m_logTimestampLogs;
 }
 
 bool CConf::getCWIdEnabled() const

--- a/Conf.h
+++ b/Conf.h
@@ -54,6 +54,7 @@ public:
   unsigned int getLogFileLevel() const;
   std::string  getLogFilePath() const;
   std::string  getLogFileRoot() const;
+  unsigned int getLogRotateLogs() const;
 
   // The CW ID section
   bool         getCWIdEnabled() const;
@@ -337,6 +338,7 @@ private:
   unsigned int m_logFileLevel;
   std::string  m_logFilePath;
   std::string  m_logFileRoot;
+  unsigned int m_logRotateLogs;
 
   bool         m_cwIdEnabled;
   unsigned int m_cwIdTime;

--- a/Conf.h
+++ b/Conf.h
@@ -54,7 +54,7 @@ public:
   unsigned int getLogFileLevel() const;
   std::string  getLogFilePath() const;
   std::string  getLogFileRoot() const;
-  unsigned int getLogRotateLogs() const;
+  unsigned int getLogTimestampLogs() const;
 
   // The CW ID section
   bool         getCWIdEnabled() const;
@@ -338,7 +338,7 @@ private:
   unsigned int m_logFileLevel;
   std::string  m_logFilePath;
   std::string  m_logFileRoot;
-  unsigned int m_logRotateLogs;
+  unsigned int m_logTimestampLogs;
 
   bool         m_cwIdEnabled;
   unsigned int m_cwIdTime;

--- a/Log.cpp
+++ b/Log.cpp
@@ -41,7 +41,7 @@ static bool m_daemon = false;
 
 static unsigned int m_displayLevel = 2U;
 
-static unsigned int m_rotateLogs = 1U;
+static unsigned int m_timestampLogs = 1U;
 
 static struct tm m_tm;
 
@@ -70,7 +70,7 @@ static bool LogOpen()
 	char filename[200U];
 	char timestamp[37U] = "";
 
-	if (m_rotateLogs) {
+	if (m_timestampLogs) {
 		::sprintf(timestamp, "-%04d-%02d-%02d", tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday);
 	}
 
@@ -94,13 +94,13 @@ static bool LogOpen()
 	return status;
 }
 
-bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, unsigned int rotateLogs)
+bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, unsigned int timestampLogs)
 {
 	m_filePath     = filePath;
 	m_fileRoot     = fileRoot;
 	m_fileLevel    = fileLevel;
 	m_displayLevel = displayLevel;
-	m_rotateLogs   = rotateLogs;
+	m_timestampLogs   = timestampLogs;
 	m_daemon       = daemon;
 
 	if (m_daemon)

--- a/Log.cpp
+++ b/Log.cpp
@@ -41,6 +41,8 @@ static bool m_daemon = false;
 
 static unsigned int m_displayLevel = 2U;
 
+static unsigned int m_rotateLogs = 1U;
+
 static struct tm m_tm;
 
 static char LEVELS[] = " DMIWEF";
@@ -66,10 +68,16 @@ static bool LogOpen()
 	}
 
 	char filename[200U];
+	char timestamp[37U] = "";
+
+	if (m_rotateLogs) {
+		::sprintf(timestamp, "-%04d-%02d-%02d", tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday);
+	}
+
 #if defined(_WIN32) || defined(_WIN64)
-	::sprintf(filename, "%s\\%s-%04d-%02d-%02d.log", m_filePath.c_str(), m_fileRoot.c_str(), tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday);
+	::sprintf(filename, "%s\\%s%s.log", m_filePath.c_str(), m_fileRoot.c_str(), timestamp);
 #else
-	::sprintf(filename, "%s/%s-%04d-%02d-%02d.log", m_filePath.c_str(), m_fileRoot.c_str(), tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday);
+	::sprintf(filename, "%s/%s%s.log", m_filePath.c_str(), m_fileRoot.c_str(), timestamp);
 #endif
 
 	if ((m_fpLog = ::fopen(filename, "a+t")) != NULL) {
@@ -86,12 +94,13 @@ static bool LogOpen()
 	return status;
 }
 
-bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel)
+bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, unsigned int rotateLogs)
 {
 	m_filePath     = filePath;
 	m_fileRoot     = fileRoot;
 	m_fileLevel    = fileLevel;
 	m_displayLevel = displayLevel;
+	m_rotateLogs   = rotateLogs;
 	m_daemon       = daemon;
 
 	if (m_daemon)

--- a/Log.h
+++ b/Log.h
@@ -30,7 +30,7 @@
 
 extern void Log(unsigned int level, const char* fmt, ...);
 
-extern bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, unsigned int rotateLogs);
+extern bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, unsigned int timestampLogs);
 extern void LogFinalise();
 
 #endif

--- a/Log.h
+++ b/Log.h
@@ -30,7 +30,7 @@
 
 extern void Log(unsigned int level, const char* fmt, ...);
 
-extern bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel);
+extern bool LogInitialise(bool daemon, const std::string& filePath, const std::string& fileRoot, unsigned int fileLevel, unsigned int displayLevel, unsigned int rotateLogs);
 extern void LogFinalise();
 
 #endif

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -26,7 +26,7 @@ DisplayLevel=1
 FileLevel=1
 FilePath=.
 FileRoot=MMDVM
-RotateLogs=1
+TimestampLogs=1
 
 [CW Id]
 Enable=1

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -26,6 +26,7 @@ DisplayLevel=1
 FileLevel=1
 FilePath=.
 FileRoot=MMDVM
+RotateLogs=1
 
 [CW Id]
 Enable=1

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -242,9 +242,9 @@ int CMMDVMHost::run()
 #endif
 
 #if !defined(_WIN32) && !defined(_WIN64)
-	ret = ::LogInitialise(m_daemon, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel());
+	ret = ::LogInitialise(m_daemon, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogRotateLogs());
 #else
-	ret = ::LogInitialise(false, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel());
+	ret = ::LogInitialise(false, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogRotateLogs());
 #endif
 	if (!ret) {
 		::fprintf(stderr, "MMDVMHost: unable to open the log file\n");

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -242,9 +242,9 @@ int CMMDVMHost::run()
 #endif
 
 #if !defined(_WIN32) && !defined(_WIN64)
-	ret = ::LogInitialise(m_daemon, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogRotateLogs());
+	ret = ::LogInitialise(m_daemon, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogTimestampLogs());
 #else
-	ret = ::LogInitialise(false, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogRotateLogs());
+	ret = ::LogInitialise(false, m_conf.getLogFilePath(), m_conf.getLogFileRoot(), m_conf.getLogFileLevel(), m_conf.getLogDisplayLevel(), m_conf.getLogTimestampLogs());
 #endif
 	if (!ret) {
 		::fprintf(stderr, "MMDVMHost: unable to open the log file\n");

--- a/RemoteCommand.cpp
+++ b/RemoteCommand.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
 CRemoteCommand::CRemoteCommand(unsigned int port) :
 m_port(port)
 {
-	::LogInitialise(false, ".", "RemoteCommand", 2U, 2U);
+	::LogInitialise(false, ".", "RemoteCommand", 2U, 2U, 1U);
 }
 
 CRemoteCommand::~CRemoteCommand()


### PR DESCRIPTION
For some deployments, using external software like `logrotate` is preferred to MMDVMHost's current way of writing logs with timestamps directly. This PR introduces a new config option `RotateLogs` in the `[Log]` section, defaulting to 1. With the default value, the current behavior is not modified. By switching the option to 0, only a single file like `MMDVM.log` is created which then can be rotated with whatever tool the user wants to use.

73,
Jacob, DL7XJ