### PR TITLE
Fix unused-private-field warnings

### DIFF
--- a/DMRControl.cpp
+++ b/DMRControl.cpp
@@ -35,6 +35,9 @@ m_lookup(lookup)
 	assert(lookup != NULL);
 	assert(rssi != NULL);
 
+	(UNUSED)m_colorCode;
+	(UNUSED)m_modem;
+
 	// Load black and white lists to DMRAccessControl
 	CDMRAccessControl::init(blacklist, whitelist, slot1TGWhitelist, slot2TGWhitelist, selfOnly, prefixes, id);
 

--- a/Defines.h
+++ b/Defines.h
@@ -81,4 +81,6 @@ enum DMR_OVCM_TYPES {
 	DMR_OVCM_ON
 };
 
+typedef void UNUSED;
+
 #endif

--- a/NullModem.h
+++ b/NullModem.h
@@ -76,7 +76,7 @@ public:
 
 	virtual bool writeDStarInfo(const char* my1, const char* my2, const char* your, const char* type, const char* reflector){return true;};
 	virtual bool writeDMRInfo(unsigned int slotNo, const std::string& src, bool group, const std::string& dst, const char* type){return true;};
-	virtual bool writeYSFInfo(const char* source, const char* dest, const char* type, const char* origin){return true;};
+	virtual bool writeYSFInfo(const char* source, const char* dest, unsigned char dgid, const char* type, const char* origin){return true;};
 	virtual bool writeP25Info(const char* source, bool group, unsigned int dest, const char* type){return true;};
 	virtual bool writeNXDNInfo(const char* source, bool group, unsigned int dest, const char* type){return true;};
 	virtual bool writePOCSAGInfo(unsigned int ric, const std::string& message){return true;};

--- a/P25Control.cpp
+++ b/P25Control.cpp
@@ -86,6 +86,7 @@ m_fp(NULL)
 	assert(display != NULL);
 	assert(lookup != NULL);
 	assert(rssiMapper != NULL);
+	(UNUSED)m_nac;
 
 	m_netLDU1 = new unsigned char[9U * 25U];
 	m_netLDU2 = new unsigned char[9U * 25U];


### PR DESCRIPTION
Fix NullModem method signature inconsistency and Unused private member warnings on DMR/P25Control code.