### PR TITLE
Avoid missconfiguration if TX=RX-QRG in Duplex-setup

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -962,6 +962,12 @@ bool CConf::read()
 	}
   }
 
+  if ( m_duplex && m_rxFrequency == m_txFrequency ) {
+    ::fprintf(stderr, "Duplex == 1 and TX == RX-QRG!\n");
+    ::fclose(fp);
+    return false;
+  }
+
   ::fclose(fp);
 
   return true;


### PR DESCRIPTION
As we have on several modes in several networks sometimes issues with loops created by missconfigured duplex-hotspots, this is a quick solution to avoid this.