### PR TITLE
Ref #683: Fix misaligned talker alias pointer

### DIFF
--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -656,7 +656,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 					if (!(m_rfTalkerId & TALKER_ID_HEADER)) {
 						if (m_rfTalkerId == TALKER_ID_NONE)
 							m_rfTalkerAlias.reset();
-						m_rfTalkerAlias.add(0, data, 7U);
+						m_rfTalkerAlias.add(0, data + 2U, 7U);
 						m_display->writeDMRTA(m_slotNo, (unsigned char*)m_rfTalkerAlias.get(), "R");
 
 						if (m_dumpTAData) {
@@ -675,7 +675,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 					if (!(m_rfTalkerId & TALKER_ID_BLOCK1)) {
 						if (m_rfTalkerId == TALKER_ID_NONE)
 							m_rfTalkerAlias.reset();
-						m_rfTalkerAlias.add(1, data, 7U);
+						m_rfTalkerAlias.add(1, data + 2U, 7U);
 						m_display->writeDMRTA(m_slotNo, (unsigned char*)m_rfTalkerAlias.get(), "R");
 
 						if (m_dumpTAData) {
@@ -694,7 +694,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 					if (!(m_rfTalkerId & TALKER_ID_BLOCK2)) {
 						if (m_rfTalkerId == TALKER_ID_NONE)
 							m_rfTalkerAlias.reset();
-						m_rfTalkerAlias.add(2, data, 7U);
+						m_rfTalkerAlias.add(2, data + 2U, 7U);
 						m_display->writeDMRTA(m_slotNo, (unsigned char*)m_rfTalkerAlias.get(), "R");
 
 						if (m_dumpTAData) {
@@ -713,7 +713,7 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 					if (!(m_rfTalkerId & TALKER_ID_BLOCK3)) {
 						if (m_rfTalkerId == TALKER_ID_NONE)
 							m_rfTalkerAlias.reset();
-						m_rfTalkerAlias.add(3, data, 7U);
+						m_rfTalkerAlias.add(3, data + 2U, 7U);
 						m_display->writeDMRTA(m_slotNo, (unsigned char*)m_rfTalkerAlias.get(), "R");
 
 						if (m_dumpTAData) {


### PR DESCRIPTION
Adding 2 byte offset to the data pointer passed to CDMRTA::add() in the "RF" section of CDMRSlot.cpp::writeModem(). Fixes the bug that incorrectly decodes talker alias coming in over RF.