### PR TITLE
revise UserDB display setting on OLED

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -642,7 +642,7 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CUMP* ump, CModem* modem)
 		bool          rotate     = conf.getOLEDRotate();
 		bool          logosaver  = conf.getOLEDLogoScreensaver();
 
-		display = new COLED(type, brightness, invert, scroll, rotate, logosaver, conf.getDMRNetworkSlot1(), conf.getDMRNetworkSlot2());
+		display = new COLED(type, brightness, invert, scroll, rotate, logosaver, conf.getDuplex());
 #endif
 	} else if (type == "CAST") {
 		display = new CCASTInfo(modem);

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -169,15 +169,15 @@ const unsigned char logo_POCSAG_bmp [] =
 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 };
 
-COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert, bool displayScroll, bool displayRotate, bool displayLogoScreensaver, bool slot1Enabled, bool slot2Enabled) :
+COLED::COLED(unsigned char displayType, unsigned char displayBrightness, bool displayInvert, bool displayScroll, bool displayRotate, bool displayLogoScreensaver, bool duplex) :
 m_displayType(displayType),
 m_displayBrightness(displayBrightness),
 m_displayInvert(displayInvert),
 m_displayScroll(displayScroll),
 m_displayRotate(displayRotate),
 m_displayLogoScreensaver(displayLogoScreensaver),
-m_slot1Enabled(slot1Enabled),
-m_slot2Enabled(slot2Enabled),
+m_duplex(duplex),
+//m_duplex(true),         // uncomment to force duplex display for testing!
 m_ipaddress(),
 m_display()
 {
@@ -382,7 +382,7 @@ int COLED::writeDMRIntEx(unsigned int slotNo, const class CUserDBentry& src, boo
     }
     // if both slots, use lines 2-3 for slot 1, lines 4-5 for slot 2
     // if single slot, use lines 2-3
-    if ( m_slot1Enabled && m_slot2Enabled ) {
+    if ( m_duplex ) {
 
         if (slotNo == 1U) {
             m_display.fillRect(0,OLED_LINE2,m_display.width(),40,BLACK);
@@ -430,7 +430,7 @@ void COLED::clearDMRInt(unsigned int slotNo)
 {
     // if both slots, use lines 2-3 for slot 1, lines 4-5 for slot 2
     // if single slot, use lines 2-3
-    if ( m_slot1Enabled && m_slot2Enabled ){
+    if ( m_duplex ){
         if (slotNo == 1U) {
             m_display.fillRect(0, OLED_LINE3, m_display.width(), 40, BLACK);
             m_display.setCursor(0,OLED_LINE3);

--- a/OLED.h
+++ b/OLED.h
@@ -41,7 +41,7 @@
 class COLED : public CDisplay 
 {
 public:
-  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert, bool displayScroll, bool displayRotate, bool displayLogoScreensaver, bool slot1Enabled, bool slot2Enabled);
+  COLED(unsigned char displayType, unsigned char displayBrighness, bool displayInvert, bool displayScroll, bool displayRotate, bool displayLogoScreensaver, bool duplex);
   virtual ~COLED();
 
   virtual bool open();
@@ -88,7 +88,7 @@ private:
   bool          m_displayScroll;
   bool          m_displayRotate;
   bool          m_displayLogoScreensaver;
-  bool          m_slot1Enabled;
+  bool          m_duplex;
   bool          m_slot2Enabled;
   std::string   m_ipaddress;
   ArduiPi_OLED  m_display;


### PR DESCRIPTION
To display UserDB on OLED, either Slot1=0/Slot2=1 or Slot1=1/Slot2=0 of [DMR Network] in MMDVM.ini was required.

Other displays such as LCDproc, HD44180 and TFTSurenoo uses duplex value of [General], OLED also uses same entry from now.