### PR TITLE
DMRDirectNetwork: (re)lookup on open()

### DIFF
--- a/DMRDirectNetwork.cpp
+++ b/DMRDirectNetwork.cpp
@@ -31,8 +31,10 @@ const unsigned int HOMEBREW_DATA_PACKET_LENGTH = 55U;
 
 
 CDMRDirectNetwork::CDMRDirectNetwork(const std::string& address, unsigned int port, unsigned int local, unsigned int id, const std::string& password, bool duplex, const char* version, bool slot1, bool slot2, HW_TYPE hwType, bool debug) :
+m_addressStr(address),
 m_addr(),
 m_addrLen(0U),
+m_port(port),
 m_id(NULL),
 m_password(password),
 m_duplex(duplex),
@@ -122,7 +124,7 @@ void CDMRDirectNetwork::setConfig(const std::string& callsign, unsigned int rxFr
 
 bool CDMRDirectNetwork::open()
 {
-	if (m_addrLen == 0U) {
+	if (CUDPSocket::lookup(m_addressStr, m_port, m_addr, m_addrLen) != 0) {
 		LogError("DMR, Could not lookup the address of the DMR Network");
 		return false;
 	}

--- a/DMRDirectNetwork.cpp
+++ b/DMRDirectNetwork.cpp
@@ -130,7 +130,7 @@ bool CDMRDirectNetwork::open()
 	LogMessage("Opening DMR Network");
 
 	m_status = WAITING_CONNECT;
-	m_timeoutTimer.stop();
+	m_timeoutTimer.start();
 	m_retryTimer.start();
 
 	return true;

--- a/DMRDirectNetwork.h
+++ b/DMRDirectNetwork.h
@@ -58,8 +58,10 @@ public:
 	virtual void close();
 
 private:
+	std::string      m_addressStr;
 	sockaddr_storage m_addr;
 	unsigned int     m_addrLen;
+	unsigned int     m_port;
 	uint8_t*         m_id;
 	std::string      m_password;
 	bool             m_duplex;


### PR DESCRIPTION
this helps when master servers change their ip address but are published as FQDN

also, first commit will most likely fix #682
