### PR TITLE
Add RemoteCommand 'status' command.

### DIFF
--- a/DMRDirectNetwork.cpp
+++ b/DMRDirectNetwork.cpp
@@ -316,6 +316,11 @@ bool CDMRDirectNetwork::writeTalkerAlias(unsigned int id, unsigned char type, co
 	return write(buffer, 15U);
 }
 
+bool CDMRDirectNetwork::isConnected() const
+{
+	return (m_status == RUNNING);
+}
+
 void CDMRDirectNetwork::close()
 {
 	LogMessage("Closing DMR Network");

--- a/DMRDirectNetwork.h
+++ b/DMRDirectNetwork.h
@@ -55,6 +55,8 @@ public:
 
 	virtual void clock(unsigned int ms);
 
+	virtual bool isConnected() const;
+
 	virtual void close();
 
 private:

--- a/DMRGatewayNetwork.cpp
+++ b/DMRGatewayNetwork.cpp
@@ -287,6 +287,11 @@ bool CDMRGatewayNetwork::writeTalkerAlias(unsigned int id, unsigned char type, c
 	return write(buffer, 15U);
 }
 
+bool CDMRGatewayNetwork::isConnected() const
+{
+	return (m_enabled && (m_addrLen != 0));
+}
+
 void CDMRGatewayNetwork::close()
 {
 	LogMessage("DMR, Closing DMR Network");

--- a/DMRGatewayNetwork.h
+++ b/DMRGatewayNetwork.h
@@ -56,6 +56,8 @@ public:
 
 	virtual void clock(unsigned int ms);
 
+	virtual bool isConnected() const;
+
 	virtual void close();
 
 private: 

--- a/DMRNetwork.h
+++ b/DMRNetwork.h
@@ -48,6 +48,8 @@ public:
 
 	virtual void clock(unsigned int ms) = 0;
 
+	virtual bool isConnected() const = 0;
+
 	virtual void close() = 0;
 
 private: 

--- a/DStarNetwork.cpp
+++ b/DStarNetwork.cpp
@@ -314,6 +314,11 @@ void CDStarNetwork::reset()
 	m_inId = 0U;
 }
 
+bool CDStarNetwork::isConnected() const
+{
+	return (m_enabled && (m_addrLen != 0));
+}
+
 void CDStarNetwork::close()
 {
 	m_socket.close();

--- a/DStarNetwork.h
+++ b/DStarNetwork.h
@@ -46,6 +46,8 @@ public:
 
 	void reset();
 
+	bool isConnected() const;
+
 	void close();
 
 	void clock(unsigned int ms);

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -635,7 +635,7 @@ int CMMDVMHost::run()
 		LogInfo("    Address: %s", address.c_str());
 		LogInfo("    Port: %u", port);
 
-		m_remoteControl = new CRemoteControl(address, port);
+		m_remoteControl = new CRemoteControl(this, address, port);
 
 		ret = m_remoteControl->open();
 		if (!ret) {
@@ -2139,4 +2139,15 @@ void CMMDVMHost::processEnableCommand(bool& mode, bool enabled)
 	m_modem->setModeParams(m_dstarEnabled, m_dmrEnabled, m_ysfEnabled, m_p25Enabled, m_nxdnEnabled, m_pocsagEnabled, m_fmEnabled);
 	if (!m_modem->writeConfig())
 		LogError("Cannot write Config to MMDVM");
+}
+
+void CMMDVMHost::buildNetworkStatusString(std::string &str)
+{
+	str = "";
+	str += std::string("dstar:") + (((m_dstarNetwork == NULL) || (m_dstarEnabled == false)) ? "n/a" : (m_dstarNetwork->isConnected() ? "conn" : "disc"));
+	str += std::string(" dmr:") + (((m_dmrNetwork == NULL) || (m_dmrEnabled == false)) ? "n/a" : (m_dmrNetwork->isConnected() ? "conn" : "disc"));
+	str += std::string(" ysf:") + (((m_ysfNetwork == NULL) || (m_ysfEnabled == false)) ? "n/a" : (m_ysfNetwork->isConnected() ? "conn" : "disc"));
+	str += std::string(" p25:") + (((m_p25Network == NULL) || (m_p25Enabled == false)) ? "n/a" : (m_p25Network->isConnected() ? "conn" : "disc"));
+	str += std::string(" nxdn:") + (((m_nxdnNetwork == NULL) || (m_nxdnEnabled == false)) ? "n/a" : (m_nxdnNetwork->isConnected() ? "conn" : "disc"));
+	str += std::string(" fm:") + (m_fmEnabled ? "conn" : "n/a");
 }

--- a/MMDVMHost.h
+++ b/MMDVMHost.h
@@ -51,6 +51,8 @@ public:
 
   int run();
 
+  void buildNetworkStatusString(std::string &str);
+
 private:
   CConf           m_conf;
   CModem*         m_modem;

--- a/NXDNIcomNetwork.cpp
+++ b/NXDNIcomNetwork.cpp
@@ -153,6 +153,11 @@ void CNXDNIcomNetwork::reset()
 {
 }
 
+bool CNXDNIcomNetwork::isConnected() const
+{
+	return (m_enabled && (m_addrLen != 0));
+}
+
 void CNXDNIcomNetwork::close()
 {
 	m_socket.close();

--- a/NXDNIcomNetwork.h
+++ b/NXDNIcomNetwork.h
@@ -43,6 +43,8 @@ public:
 
 	virtual void reset();
 
+	virtual bool isConnected() const;
+
 	virtual void close();
 
 	virtual void clock(unsigned int ms);

--- a/NXDNKenwoodNetwork.cpp
+++ b/NXDNKenwoodNetwork.cpp
@@ -835,6 +835,11 @@ void CNXDNKenwoodNetwork::reset()
 	m_seen4 = false;
 }
 
+bool CNXDNKenwoodNetwork::isConnected() const
+{
+	return (m_enabled && (m_rtcpAddrLen != 0U) && (m_rtpAddrLen != 0U));
+}
+
 void CNXDNKenwoodNetwork::close()
 {
 	m_rtcpSocket.close();

--- a/NXDNKenwoodNetwork.h
+++ b/NXDNKenwoodNetwork.h
@@ -42,6 +42,8 @@ public:
 
 	virtual void reset();
 
+	virtual bool isConnected() const;
+
 	virtual void close();
 
 	virtual void clock(unsigned int ms);

--- a/NXDNNetwork.h
+++ b/NXDNNetwork.h
@@ -46,6 +46,8 @@ public:
 
 	virtual void reset() = 0;
 
+	virtual bool isConnected() const = 0;
+
 	virtual void close() = 0;
 
 	virtual void clock(unsigned int ms) = 0;

--- a/P25Network.cpp
+++ b/P25Network.cpp
@@ -424,6 +424,11 @@ unsigned int CP25Network::read(unsigned char* data, unsigned int length)
 	return c;
 }
 
+bool CP25Network::isConnected() const
+{
+	return (m_enabled && (m_addrLen != 0));
+}
+
 void CP25Network::close()
 {
 	m_socket.close();

--- a/P25Network.h
+++ b/P25Network.h
@@ -43,6 +43,8 @@ public:
 
 	unsigned int read(unsigned char* data, unsigned int length);
 
+	bool isConnected() const;
+
 	void close();
 
 	void clock(unsigned int ms);

--- a/RemoteCommand.cpp
+++ b/RemoteCommand.cpp
@@ -75,7 +75,7 @@ int CRemoteCommand::send(const std::string& command)
 	int retStatus = 0;
 
 	if (CUDPSocket::lookup("127.0.0.1", m_port, addr, addrLen) != 0) {
-		LogError("Unable to resolve the address of the host");
+		::fprintf(stderr, "Unable to resolve the address of the host\n");
 		return 1;
 	}
 
@@ -91,14 +91,14 @@ int CRemoteCommand::send(const std::string& command)
 		return 1;
 	}
 
-	LogMessage("Command sent: \"%s\" to port: %u", command.c_str(), m_port);
+	::fprintf(stdout, "Command sent: \"%s\" to port: %u\n", command.c_str(), m_port);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 	
-	int len = socket.read((unsigned char*)&buffer[0], BUFFER_LENGTH, addr, addrLen);
+	int len = socket.read((unsigned char*)buffer, BUFFER_LENGTH, addr, addrLen);
 	if (len > 0) {
 		buffer[len] = '\0';
-		LogMessage("%s", buffer);
+		::fprintf(stdout, "%s\n", buffer);
 	}
 	else
 	{

--- a/RemoteControl.cpp
+++ b/RemoteControl.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "RemoteControl.h"
+#include "MMDVMHost.h"
 #include "Log.h"
 
 #include <cstdio>
@@ -32,7 +33,8 @@ const unsigned int CW_ARGS = 2U;
 
 const unsigned int BUFFER_LENGTH = 100U;
 
-CRemoteControl::CRemoteControl(const std::string address, unsigned int port) :
+CRemoteControl::CRemoteControl(CMMDVMHost *host, const std::string address, unsigned int port) :
+m_host(host),
 m_socket(address, port),
 m_command(RCD_NONE),
 m_args()
@@ -131,7 +133,16 @@ REMOTE_COMMAND CRemoteControl::getCommand()
 		} else if (m_args.at(0U) == "reload") {
                         // Reload command is in the form of "reload"
                         m_command = RCD_RELOAD;
-                }
+		} else if (m_args.at(0U) == "status") {
+			if (m_host != NULL) {
+				m_host->buildNetworkStatusString(replyStr);
+			}
+			else {
+				replyStr = "KO";
+			}
+
+			m_command = RCD_CONNECTION_STATUS;
+		}
 		else
 			replyStr = "KO";
 

--- a/RemoteControl.h
+++ b/RemoteControl.h
@@ -24,6 +24,8 @@
 #include <vector>
 #include <string>
 
+class CMMDVMHost;
+
 enum REMOTE_COMMAND {
 	RCD_NONE,
 	RCD_MODE_IDLE,
@@ -48,12 +50,13 @@ enum REMOTE_COMMAND {
 	RCD_DISABLE_FM,
 	RCD_PAGE,
 	RCD_CW,
-	RCD_RELOAD
+	RCD_RELOAD,
+	RCD_CONNECTION_STATUS
 };
 
 class CRemoteControl {
 public:
-	CRemoteControl(const std::string address, unsigned int port);
+	CRemoteControl(class CMMDVMHost *host, const std::string address, unsigned int port);
 	~CRemoteControl();
 
 	bool open();
@@ -69,6 +72,7 @@ public:
 	void close();
 
 private:
+	CMMDVMHost*              m_host;
 	CUDPSocket               m_socket;
 	REMOTE_COMMAND           m_command;
 	std::vector<std::string> m_args;

--- a/YSFNetwork.cpp
+++ b/YSFNetwork.cpp
@@ -183,6 +183,11 @@ void CYSFNetwork::reset()
 	::memset(m_tag, ' ', YSF_CALLSIGN_LENGTH);
 }
 
+bool CYSFNetwork::isConnected() const
+{
+	return (m_enabled && (m_addrLen != 0));
+}
+
 void CYSFNetwork::close()
 {
 	m_socket.close();

--- a/YSFNetwork.h
+++ b/YSFNetwork.h
@@ -42,6 +42,8 @@ public:
 
 	void reset();
 
+	bool isConnected() const;
+
 	void close();
 
 	void clock(unsigned int ms);


### PR DESCRIPTION
As DMRGateway, it reports connection status.

Command sent: "status" to port: 7642
dstar:n/a dmr:conn ysf:n/a p25:n/a nxdn:n/a fm:n/a

RemoveCommand has been slighlty modified, as using Log on a read-only filesystem simply forbids the strings to be displayed.
Another solution would be to set LogInitialisse's filePath to "/tmp/" for *nix systems.