### PR TITLE
Fix *Network::isConnected().

### DIFF
--- a/DMRGatewayNetwork.cpp
+++ b/DMRGatewayNetwork.cpp
@@ -289,7 +289,7 @@ bool CDMRGatewayNetwork::writeTalkerAlias(unsigned int id, unsigned char type, c
 
 bool CDMRGatewayNetwork::isConnected() const
 {
-	return (m_enabled && (m_addrLen != 0));
+	return (m_addrLen != 0);
 }
 
 void CDMRGatewayNetwork::close()

--- a/DStarNetwork.cpp
+++ b/DStarNetwork.cpp
@@ -316,7 +316,7 @@ void CDStarNetwork::reset()
 
 bool CDStarNetwork::isConnected() const
 {
-	return (m_enabled && (m_addrLen != 0));
+	return (m_addrLen != 0);
 }
 
 void CDStarNetwork::close()

--- a/NXDNIcomNetwork.cpp
+++ b/NXDNIcomNetwork.cpp
@@ -155,7 +155,7 @@ void CNXDNIcomNetwork::reset()
 
 bool CNXDNIcomNetwork::isConnected() const
 {
-	return (m_enabled && (m_addrLen != 0));
+	return (m_addrLen != 0);
 }
 
 void CNXDNIcomNetwork::close()

--- a/NXDNKenwoodNetwork.cpp
+++ b/NXDNKenwoodNetwork.cpp
@@ -837,7 +837,7 @@ void CNXDNKenwoodNetwork::reset()
 
 bool CNXDNKenwoodNetwork::isConnected() const
 {
-	return (m_enabled && (m_rtcpAddrLen != 0U) && (m_rtpAddrLen != 0U));
+	return ((m_rtcpAddrLen != 0U) && (m_rtpAddrLen != 0U));
 }
 
 void CNXDNKenwoodNetwork::close()

--- a/P25Network.cpp
+++ b/P25Network.cpp
@@ -426,7 +426,7 @@ unsigned int CP25Network::read(unsigned char* data, unsigned int length)
 
 bool CP25Network::isConnected() const
 {
-	return (m_enabled && (m_addrLen != 0));
+	return (m_addrLen != 0);
 }
 
 void CP25Network::close()

--- a/YSFNetwork.cpp
+++ b/YSFNetwork.cpp
@@ -185,7 +185,7 @@ void CYSFNetwork::reset()
 
 bool CYSFNetwork::isConnected() const
 {
-	return (m_enabled && (m_addrLen != 0));
+	return (m_addrLen != 0);
 }
 
 void CYSFNetwork::close()


### PR DESCRIPTION
As m_enabled is changed accordingly to the modem current mode, it's not valid to use it for network connexion status.