### PR TITLE
DMRSlot: reset m_rfState after rejecting rf activity

### DIFF
--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -224,12 +224,14 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (!CDMRAccessControl::validateSrcId(srcId)) {
 				LogMessage("DMR Slot %u, RF user %u rejected", m_slotNo, srcId);
 				delete lc;
+				m_rfState = RS_RF_LISTENING;
 				return false;
 			}
 
 			if (!CDMRAccessControl::validateTGId(m_slotNo, flco == FLCO_GROUP, dstId)) {
 				LogMessage("DMR Slot %u, RF user %u rejected for using TG %u", m_slotNo, srcId, dstId);
 				delete lc;
+				m_rfState = RS_RF_LISTENING;
 				return false;
 			}
 
@@ -383,11 +385,13 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 
 			if (!CDMRAccessControl::validateSrcId(srcId)) {
 				LogMessage("DMR Slot %u, RF user %u rejected", m_slotNo, srcId);
+				m_rfState = RS_RF_LISTENING;
 				return false;
 			}
 
 			if (!CDMRAccessControl::validateTGId(m_slotNo, gi, dstId)) {
 				LogMessage("DMR Slot %u, RF user %u rejected for using TG %u", m_slotNo, srcId, dstId);
+				m_rfState = RS_RF_LISTENING;
 				return false;
 			}
 
@@ -454,11 +458,13 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (srcId != 0U || dstId != 0U) {
 				if (!CDMRAccessControl::validateSrcId(srcId)) {
 					LogMessage("DMR Slot %u, RF user %u rejected", m_slotNo, srcId);
+					m_rfState = RS_RF_LISTENING;
 					return false;
 				}
 
 				if (!CDMRAccessControl::validateTGId(m_slotNo, gi, dstId)) {
 					LogMessage("DMR Slot %u, RF user %u rejected for using TG %u", m_slotNo, srcId, dstId);
+					m_rfState = RS_RF_LISTENING;
 					return false;
 				}
 			}
@@ -793,12 +799,14 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 				if (!CDMRAccessControl::validateSrcId(srcId)) {
 					LogMessage("DMR Slot %u, RF user %u rejected", m_slotNo, srcId);
 					delete lc;
+					m_rfState = RS_RF_LISTENING;
 					return false;
 				}
 
 				if (!CDMRAccessControl::validateTGId(m_slotNo, flco == FLCO_GROUP, dstId)) {
 					LogMessage("DMR Slot %u, RF user %u rejected for using TG %u", m_slotNo, srcId, dstId);
 					delete lc;
+					m_rfState = RS_RF_LISTENING;
 					return false;
 				}
 


### PR DESCRIPTION
as title says.

this fixes an issue with Slot1TGWhiteList / Slot2TGWhiteList / WhiteList / BlackList where MMDVMHost stops forwarding calls after rejecting matching call via rf.

