### PR TITLE
OSX build error fixes

### DIFF
--- a/ModemPort.h
+++ b/ModemPort.h
@@ -30,6 +30,9 @@ public:
 	virtual int write(const unsigned char* buffer, unsigned int length) = 0;
 
 	virtual void close() = 0;
+#if defined(__APPLE__)
+	virtual int setNonblock(bool nonblock) = 0;
+#endif
 
 private:
 };

--- a/NullController.h
+++ b/NullController.h
@@ -35,6 +35,10 @@ public:
 	virtual int write(const unsigned char* buffer, unsigned int length);
 
 	virtual void close();
+	
+#if defined(__APPLE__)
+	int setNonblock(bool nonblock) { return 0; }
+#endif
 
 private:
 	CRingBuffer<unsigned char> m_buffer;

--- a/PseudoTTYController.cpp
+++ b/PseudoTTYController.cpp
@@ -32,7 +32,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
-#include <pty.h>
+#if defined(__APPLE__)
+	#include <util.h>
+#else
+	#include <pty.h>
+#endif
 
 
 CPseudoTTYController::CPseudoTTYController(const std::string& symlink, unsigned int speed, bool assertRTS) :

--- a/UARTController.cpp
+++ b/UARTController.cpp
@@ -328,8 +328,13 @@ bool CUARTController::setRaw()
 			::cfsetispeed(&termios, B230400);
 			break;
 		case 460800U:
-			::cfsetospeed(&termios, B460800);
-			::cfsetispeed(&termios, B460800);
+#if defined(__APPLE__)
+			::cfsetospeed(&termios, 460800);
+			::cfsetispeed(&termios, 460800);
+#else
+ 			::cfsetospeed(&termios, B460800);
+ 			::cfsetispeed(&termios, B460800);
+#endif
 			break;
 		default:
 			LogError("Unsupported serial port speed - %u", m_speed);

--- a/UDPController.h
+++ b/UDPController.h
@@ -37,6 +37,10 @@ public:
 	virtual int write(const unsigned char* buffer, unsigned int length);
 
 	virtual void close();
+	
+#if defined(__APPLE__)
+	int setNonblock(bool nonblock) { return 0; }
+#endif
 
 protected:
 	CUDPSocket       m_socket;


### PR DESCRIPTION
3 build errors on OSX:  The missing virtual method declare in base class, use of a different header file for OSX, and non-existent symbol B460800 for seial port speed on OSX.  I don't know why that symbol doesn't exist on OSX but I can confirm that 460800 speed is supported on OSX.