### PR TITLE
Fix POCSAG string...   again.

### DIFF
--- a/HD44780.cpp
+++ b/HD44780.cpp
@@ -1053,7 +1053,7 @@ void CHD44780::clearNXDNInt()
 void CHD44780::writePOCSAGInt(uint32_t ric, const std::string& message)
 {
 	::lcdPosition(m_fd, m_cols - 5, m_rows - 1);
-	::lcdPuts(m_fd, "POCSAG");                 //  Shortened "POCSAG TX" to 5 characters because it wraps around onto the next line (or on 16x2 displays the 1st line).
+	::lcdPuts(m_fd, "POCSG");                 //  Shortened "POCSAG TX" to 5 characters because it wraps around onto the next line (or on 16x2 displays the 1st line).
 }
 
 void CHD44780::clearPOCSAGInt()


### PR DESCRIPTION
Sorry made an oversight and left the string POCSAG one character too long.

In order for the length of the string to be greater than 5 it would require modifying many areas of the code, so I attempted to shorten it to something acceptable instead of making major sweeping changes.