### PR TITLE
permit inline comment(3)

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -435,7 +435,7 @@ bool CConf::read()
 			continue;
 		}
 
-		char* key   = ::strtok(buffer, " \t=\r\n");
+		char* key = ::strtok(buffer, " \t=\r\n");
 		if (key == NULL)
 			continue;
 
@@ -449,8 +449,15 @@ bool CConf::read()
 			value[len - 1U] = '\0';
 			value++;
 		} else {
+			char *p;
+
 			// if value is not quoted, remove after # (to make comment)
-			(void)::strtok(value, "#");
+			if ((p = strchr(value, '#')) != NULL)
+				*p = '\0';
+
+			// remove trailing tab/space
+			for (p = value + strlen(value) - 1U; p >= value && (*p == '\t' || *p == ' '); p--)
+				*p = '\0';
 		}
 
 		if (section == SECTION_GENERAL) {


### PR DESCRIPTION
https://github.com/g4klx/MMDVMHost/commit/d77e2a00ce05ed5e5d0188e7ee8a20ebd95b1e1a removes previous inline-comment improvement (https://github.com/g4klx/MMDVMHost/commit/15a8e87c3ecc9c770271de65b1937b5e433e152b and https://github.com/g4klx/MMDVMHost/commit/1ded19c5b2c00490c0f4f16c872e5a926d4f5b9f).
This PR regain the feature, referring to https://github.com/g4klx/DAPNETGateway/commit/471f5475d28ffa9ee0843ad9a2ea5fd47c84bbb3