### PR TITLE
TFTSurenoo: initialize improvement

### DIFF
--- a/TFTSurenoo.cpp
+++ b/TFTSurenoo.cpp
@@ -121,10 +121,6 @@ bool CTFTSurenoo::open()
 
 	lcdReset();
 	clearScreen(BG_COLOUR);
-
-	setRotation(ROTATION_LANDSCAPE);
-	setBrightness(m_brightness);
-	setBackground(BG_COLOUR);
 	setIdle();
 
 	m_refreshTimer.start();
@@ -455,6 +451,13 @@ void CTFTSurenoo::refreshDisplay(void)
 	// send CR+LF to avoid first command is not processed
 	::snprintf(m_temp, sizeof(m_temp), STR_CRLF);
 	m_serial->write((unsigned char*)m_temp, (unsigned int)::strlen(m_temp));
+
+	// config display
+	setRotation(ROTATION_LANDSCAPE);
+	setBrightness(m_brightness);
+	setBackground(BG_COLOUR);
+	m_serial->write((unsigned char*)m_temp, (unsigned int)::strlen(m_temp));
+	CThread::sleep(5);
 
 	// clear display
 	::snprintf(m_temp, sizeof(m_temp), "BOXF(%d,%d,%d,%d,%d);",


### PR DESCRIPTION
Sometimes the timing of transmitted data through Nextion UART port on MMDVM board is not accurate. For example, 250ms delay of lcdReset() is ignored.

(via MMDVM LCD-UART port)
```
[2021/10/29 23:04:57.481] RESET;
[2021/10/29 23:04:57.482] CLR(0);
[2021/10/29 23:04:58.100]
[2021/10/29 23:04:58.101] DIR(1);BL(50);SBC(0);
[2021/10/29 23:04:58.142] BOXF(0,0,159,127,0);DCV24(0,0,'MMDVM',4);DCV16(0,32,'JG1UAA / 440xxxx',5);DCV16(0,48,'IDLE',5);
```
(via native serial port)
```
[2021/10/30 08:11:21.587] RESET;
[2021/10/30 08:11:21.827] CLR(0);
[2021/10/30 08:11:37.478]
[2021/10/30 08:11:37.480] DIR(1);BL(50);SBC(0);
[2021/10/30 08:11:37.498] BOXF(0,0,159,127,0);DCV24(0,0,'MMDVM',4);DCV16(0,32,'JG1UAA / 440xxxx',5);DCV16(0,48,'IDLE',5);
```
Ignoring screen direction(DIR), background color(SBC) breaks screen layout.
To solve this, send some LCD configuration command at refreshDisplay().
This is not smart solution, but inevitable.