### PR TITLE
fix UART setNonblock bug.

### DIFF
--- a/UARTController.cpp
+++ b/UARTController.cpp
@@ -400,7 +400,7 @@ bool CUARTController::setRaw()
 #if defined(__APPLE__)
 int CUARTController::setNonblock(bool nonblock)
 {
-	int flag = ::fcntl(m_fd, F_GETFD, 0);
+	int flag = ::fcntl(m_fd, F_GETFL, 0);
 
 	if (nonblock)
 		flag |= O_NONBLOCK;


### PR DESCRIPTION
According to the the man page of fcntl, we should use F_GETFL to get flags.

The flags for the F_GETFD and F_SETFD commands are as follows:

           FD_CLOEXEC   Close-on-exec; the given file descriptor will be automatically closed in the successor process image when one of the execv(2) or posix_spawn(2) family of
                        system calls is invoked.

The flags for the F_GETFL and F_SETFL commands are as follows:

           O_NONBLOCK   Non-blocking I/O; if no data is available to a read call, or if a write operation would block, the read or write call returns -1 with the error EAGAIN.

           O_APPEND     Force each write to append at the end of file; corresponds to the O_APPEND flag of open(2).

           O_ASYNC      Enable the SIGIO signal to be sent to the process group when I/O is possible, e.g., upon availability of data to be read.