### PR TITLE
Adding high speed UART Speed support for Armbian + AllWinner H2/H3

### DIFF
--- a/UARTController.cpp
+++ b/UARTController.cpp
@@ -357,6 +357,12 @@ bool CUARTController::setRaw()
  			::cfsetispeed(&termios, B460800);
 			break;
 #endif /*B460800*/
+#if defined(B500000)
+                case 500000U:
+                        ::cfsetospeed(&termios, B500000);
+                        ::cfsetispeed(&termios, B500000);
+                        break;
+#endif /*B500000*/
 		default:
 			LogError("Unsupported serial port speed - %u", m_speed);
 			::close(m_fd);


### PR DESCRIPTION
The AllWinner H2/H3 SOCs and stock Armbian linux use a UART clock not cable of 460800, which is recommended for FM mode network communication between the MODEM (mmdvm) and Host (mmdvmhost). This adds support for 500000 which is supported, and also supported by at least the STM32F4 and STM32F7 series.