### PR TITLE
Add ability for RemoteCommand to send commands to non-localhost addresses

### DIFF
--- a/RemoteCommand.cpp
+++ b/RemoteCommand.cpp
@@ -25,19 +25,21 @@
 #include <chrono>
 #include <thread>
 
+
 const unsigned int BUFFER_LENGTH = 1024U;
 
-int main(int argc, char** argv)
-{
-	if (argc < 3) {
-		::fprintf(stderr, "Usage: RemoteCommand <port> <command> [argument]\n");
+
+int main(int argc, char *argv[]) {
+	if (argc < 4) {
+		::fprintf(stderr, "Usage: RemoteCommand <address> <port> <command> [argument]\n");
 		return 1;
 	}
-	
-	unsigned int port = (unsigned int)::atoi(argv[1]);
-	std::string cmd = std::string(argv[2]);
 
-	for (int i = 3; i < argc; i++) {
+	std::string host = std::string(argv[1]);
+	unsigned int port = (unsigned int)::atoi(argv[2]);
+	std::string cmd = std::string(argv[3]);
+
+	for (int i = 4; i < argc; i++) {
 		cmd += " ";
 		cmd += std::string(argv[i]);
 	}
@@ -47,43 +49,46 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
-	CRemoteCommand* command = new CRemoteCommand(port);
-	
+	CRemoteCommand *command = new CRemoteCommand(host, port);
+
 	return command->send(cmd);
 }
 
-CRemoteCommand::CRemoteCommand(unsigned int port) :
-m_port(port)
-{
+CRemoteCommand::CRemoteCommand(unsigned int port): m_port(port) {
 	CUDPSocket::startup();
 
 	::LogInitialise(false, ".", "RemoteCommand", 2U, 2U, false);
 }
 
-CRemoteCommand::~CRemoteCommand()
-{
+CRemoteCommand::CRemoteCommand(const std::string &host, unsigned int port): m_host(host), m_port(port) {
+	CUDPSocket::startup();
+
+	::LogInitialise(false, ".", "RemoteCommand", 2U, 2U, false);
+}
+
+CRemoteCommand::~CRemoteCommand() {
 	::LogFinalise();
 
 	CUDPSocket::shutdown();
 }
 
-int CRemoteCommand::send(const std::string& command)
-{
+int CRemoteCommand::send(const std::string &command) {
 	sockaddr_storage addr;
 	unsigned int addrLen;
 	char buffer[BUFFER_LENGTH];
 	int retStatus = 0;
 
-	if (CUDPSocket::lookup("127.0.0.1", m_port, addr, addrLen) != 0) {
+	if (CUDPSocket::lookup(m_host, m_port, addr, addrLen) != 0) {
 		::fprintf(stderr, "Unable to resolve the address of the host\n");
 		return 1;
 	}
 
 	CUDPSocket socket(0U);
-	
+
 	bool ret = socket.open(addr);
-	if (!ret)
+	if (!ret) {
 		return 1;
+	}
 
 	ret = socket.write((unsigned char*)command.c_str(), command.length(), addr, addrLen);
 	if (!ret) {
@@ -94,17 +99,15 @@ int CRemoteCommand::send(const std::string& command)
 	::fprintf(stdout, "Command sent: \"%s\" to port: %u\n", command.c_str(), m_port);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
-	
+
 	int len = socket.read((unsigned char*)buffer, BUFFER_LENGTH, addr, addrLen);
 	if (len > 0) {
 		buffer[len] = '\0';
 		::fprintf(stdout, "%s\n", buffer);
-	}
-	else
-	{
+	} else {
 		retStatus = 1;
 	}
-	
+
 	socket.close();
 
 	return retStatus;

--- a/RemoteCommand.h
+++ b/RemoteCommand.h
@@ -16,21 +16,24 @@
  *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#ifndef RemoteCommand_H
-#define RemoteCommand_H
+#ifndef RemoteCommand_H_
+#define RemoteCommand_H_
 
 #include <string>
 
-class CRemoteCommand
-{
+
+class CRemoteCommand {
 public:
 	CRemoteCommand(unsigned int port);
+	CRemoteCommand(const std::string &host, unsigned int port);
 	~CRemoteCommand();
-	
-	int send(const std::string& command);
+
+	int send(const std::string &command);
 
 private:
+	std::string m_host;
 	unsigned int m_port;
 };
 
-#endif
+
+#endif	/* !RemoteCommand_H_ */


### PR DESCRIPTION
These changes allow one to specify the hostname/address for which `RemoteCommand` will send its command to; this allows
one the ability to use the `RemoteCommand` utility to control an `MMDVMHost` instance running on another host (ie: send
commands to a **pi-star** instance on one's local network from a desktop host).
