### PR TITLE
Fix OLED.cpp: fix issue where display would not fully clear on idle when LogoScreensaver = 0

### DIFF
--- a/OLED.cpp
+++ b/OLED.cpp
@@ -258,6 +258,10 @@ void COLED::setIdleInt()
     m_display.clearDisplay();
     OLED_statusbar();
 
+    if (m_displayScroll && m_displayLogoScreensaver)
+        m_display.startscrolldiagleft(0x00,0x0f);  //the MMDVM logo scrolls the whole screen
+    m_display.display();
+
     unsigned char info[100U];
     CNetworkInfo* m_network;
 
@@ -320,9 +324,6 @@ void COLED::setIdleInt()
 	m_display.printf("%s", m_ipaddress.c_str());
     }
 
-    if (m_displayScroll && m_displayLogoScreensaver)
-	m_display.startscrolldiagleft(0x00,0x0f);  // the MMDVM logo scrolls the whole screen
-    m_display.display();
 }
 
 void COLED::setErrorInt(const char* text)


### PR DESCRIPTION
My prior PRs to `OLED.cpp` introduced a bug where the display would not fully clear if the user set `LogoScreensaver = 1`.  This PR addresses that issue.