### PR TITLE
Fix memcpy overflow, as src and dest are 32 bytes long, only 31 bytes has to be copied, not 32, since an offset is applied to src.

### DIFF
--- a/DMRTA.cpp
+++ b/DMRTA.cpp
@@ -98,7 +98,7 @@ bool CDMRTA::decodeTA()
 
 		case 1U:		// ISO 8 bit
 		case 2U:		// UTF8
-			::memcpy(m_ta, m_buf + 1U, sizeof(m_ta));
+			::memcpy(m_ta, m_buf + 1U, sizeof(m_ta) - 1);
 			break;
 
 		case 3U: {		// UTF16 poor man's conversion


### PR DESCRIPTION
…