### PR TITLE
Includes cstdint for g++ builds.

### DIFF
--- a/M17Utils.cpp
+++ b/M17Utils.cpp
@@ -20,6 +20,7 @@
 #include "M17Defines.h"
 
 #include <cassert>
+#include <cstdint>
 
 const std::string M17_CHARS = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";
 

--- a/NullController.cpp
+++ b/NullController.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cassert>
+#include <cstdint>
 
 const unsigned char MMDVM_FRAME_START = 0xE0U;
 


### PR DESCRIPTION
I noticed cstdint was missing in a couple files and wouldn't build on linux.