### PR TITLE
Fix trellis decoder/encoder bit order

### DIFF
--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -531,23 +531,33 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (m_rfState != RS_RF_DATA || m_rfFrames == 0U)
 				return false;
 
-			// Regenerate the rate 1/2 payload
-			if (dataType == DT_RATE_12_DATA) {
-				CBPTC19696 bptc;
-				unsigned char payload[12U];
-				bptc.decode(data + 2U, payload);
-				bptc.encode(payload, data + 2U);
-			} else if (dataType == DT_RATE_34_DATA) {
-				CDMRTrellis trellis;
-				unsigned char payload[18U];
-				bool ret = trellis.decode(data + 2U, payload);
-				if (ret) {
-					trellis.encode(payload, data + 2U);
-				} else {
-					LogMessage("DMR Slot %u, unfixable RF rate 3/4 data", m_slotNo);
-					CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
-				}
-			}
+            char title[80U];
+            // Regenerate the rate 1/2 payload
+            if (dataType == DT_RATE_12_DATA) {
+                CBPTC19696 bptc;
+                unsigned char payload[12U];
+                bptc.decode(data + 2U, payload);
+                ::sprintf(title, "DMR Slot %u, Data 1/2", m_slotNo);
+                CUtils::dump(1U, title, payload, 12U);
+                bptc.encode(payload, data + 2U);
+            } else if (dataType == DT_RATE_34_DATA) {
+                CDMRTrellis trellis;
+                unsigned char payload[18U];
+                bool ret = trellis.decode(data + 2U, payload);
+                if (ret) {
+                    ::sprintf(title, "DMR Slot %u, Data 3/4", m_slotNo);
+                    CUtils::dump(1U, title, payload, 18U);
+                    trellis.encode(payload, data + 2U);
+                } else {
+                    LogMessage("DMR Slot %u, unfixable RF rate 3/4 data", m_slotNo);
+                    CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
+                }
+            }
+            else
+            {
+                ::sprintf(title, "DMR Slot %u, Data 1/1", m_slotNo);
+                CUtils::dump(1U, title, data + 2U, 24U);
+            }
 
 			// Regenerate the Slot Type
 			slotType.getData(data + 2U);
@@ -1716,23 +1726,34 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 			return;
 		}
 
-		// Regenerate the rate 1/2 payload
-		if (dataType == DT_RATE_12_DATA) {
-			CBPTC19696 bptc;
-			unsigned char payload[12U];
-			bptc.decode(data + 2U, payload);
-			bptc.encode(payload, data + 2U);
-		} else if (dataType == DT_RATE_34_DATA) {
-			CDMRTrellis trellis;
-			unsigned char payload[18U];
-			bool ret = trellis.decode(data + 2U, payload);
-			if (ret) {
-				trellis.encode(payload, data + 2U);
-			} else {
-				LogMessage("DMR Slot %u, unfixable network rate 3/4 data", m_slotNo);
-				CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
-			}
-		}
+        char title[80U];
+        // Regenerate the rate 1/2 payload
+        if (dataType == DT_RATE_12_DATA) {
+            CBPTC19696 bptc;
+            unsigned char payload[12U];
+            bptc.decode(data + 2U, payload);
+            ::sprintf(title, "DMR Slot %u, Data 1/2", m_slotNo);
+            CUtils::dump(1U, title, payload, 12U);
+            bptc.encode(payload, data + 2U);
+        } else if (dataType == DT_RATE_34_DATA) {
+            CDMRTrellis trellis;
+            unsigned char payload[18U];
+            bool ret = trellis.decode(data + 2U, payload);
+            if (ret) {
+                ::sprintf(title, "DMR Slot %u, Data 3/4", m_slotNo);
+                CUtils::dump(1U, title, payload, 18U);
+                trellis.encode(payload, data + 2U);
+            } else {
+                LogMessage("DMR Slot %u, unfixable network rate 3/4 data", m_slotNo);
+                CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
+            }
+        }
+        else
+        {
+            ::sprintf(title, "DMR Slot %u, Data 1/1", m_slotNo);
+            CUtils::dump(1U, title, data + 2U, 24U);
+        }
+
 
 		// Regenerate the Slot Type
 		CDMRSlotType slotType;

--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -531,33 +531,33 @@ bool CDMRSlot::writeModem(unsigned char *data, unsigned int len)
 			if (m_rfState != RS_RF_DATA || m_rfFrames == 0U)
 				return false;
 
-            char title[80U];
-            // Regenerate the rate 1/2 payload
-            if (dataType == DT_RATE_12_DATA) {
-                CBPTC19696 bptc;
-                unsigned char payload[12U];
-                bptc.decode(data + 2U, payload);
-                ::sprintf(title, "DMR Slot %u, Data 1/2", m_slotNo);
-                CUtils::dump(1U, title, payload, 12U);
-                bptc.encode(payload, data + 2U);
-            } else if (dataType == DT_RATE_34_DATA) {
-                CDMRTrellis trellis;
-                unsigned char payload[18U];
-                bool ret = trellis.decode(data + 2U, payload);
-                if (ret) {
-                    ::sprintf(title, "DMR Slot %u, Data 3/4", m_slotNo);
-                    CUtils::dump(1U, title, payload, 18U);
-                    trellis.encode(payload, data + 2U);
-                } else {
-                    LogMessage("DMR Slot %u, unfixable RF rate 3/4 data", m_slotNo);
-                    CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
-                }
-            }
-            else
-            {
-                ::sprintf(title, "DMR Slot %u, Data 1/1", m_slotNo);
-                CUtils::dump(1U, title, data + 2U, 24U);
-            }
+			char title[80U];
+			// Regenerate the rate 1/2 payload
+			if (dataType == DT_RATE_12_DATA) {
+				CBPTC19696 bptc;
+				unsigned char payload[12U];
+				bptc.decode(data + 2U, payload);
+				::sprintf(title, "DMR Slot %u, Data 1/2", m_slotNo);
+				CUtils::dump(1U, title, payload, 12U);
+				bptc.encode(payload, data + 2U);
+			} else if (dataType == DT_RATE_34_DATA) {
+				CDMRTrellis trellis;
+				unsigned char payload[18U];
+				bool ret = trellis.decode(data + 2U, payload);
+				if (ret) {
+					::sprintf(title, "DMR Slot %u, Data 3/4", m_slotNo);
+					CUtils::dump(1U, title, payload, 18U);
+					trellis.encode(payload, data + 2U);
+				} else {
+					LogMessage("DMR Slot %u, unfixable RF rate 3/4 data", m_slotNo);
+					CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
+				}
+			}
+			else
+			{
+				::sprintf(title, "DMR Slot %u, Data 1/1", m_slotNo);
+				CUtils::dump(1U, title, data + 2U, 24U);
+			}
 
 			// Regenerate the Slot Type
 			slotType.getData(data + 2U);
@@ -1726,33 +1726,33 @@ void CDMRSlot::writeNetwork(const CDMRData& dmrData)
 			return;
 		}
 
-        char title[80U];
-        // Regenerate the rate 1/2 payload
-        if (dataType == DT_RATE_12_DATA) {
-            CBPTC19696 bptc;
-            unsigned char payload[12U];
-            bptc.decode(data + 2U, payload);
-            ::sprintf(title, "DMR Slot %u, Data 1/2", m_slotNo);
-            CUtils::dump(1U, title, payload, 12U);
-            bptc.encode(payload, data + 2U);
-        } else if (dataType == DT_RATE_34_DATA) {
-            CDMRTrellis trellis;
-            unsigned char payload[18U];
-            bool ret = trellis.decode(data + 2U, payload);
-            if (ret) {
-                ::sprintf(title, "DMR Slot %u, Data 3/4", m_slotNo);
-                CUtils::dump(1U, title, payload, 18U);
-                trellis.encode(payload, data + 2U);
-            } else {
-                LogMessage("DMR Slot %u, unfixable network rate 3/4 data", m_slotNo);
-                CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
-            }
-        }
-        else
-        {
-            ::sprintf(title, "DMR Slot %u, Data 1/1", m_slotNo);
-            CUtils::dump(1U, title, data + 2U, 24U);
-        }
+		char title[80U];
+		// Regenerate the rate 1/2 payload
+		if (dataType == DT_RATE_12_DATA) {
+			CBPTC19696 bptc;
+			unsigned char payload[12U];
+			bptc.decode(data + 2U, payload);
+			::sprintf(title, "DMR Slot %u, Data 1/2", m_slotNo);
+			CUtils::dump(1U, title, payload, 12U);
+			bptc.encode(payload, data + 2U);
+		} else if (dataType == DT_RATE_34_DATA) {
+			CDMRTrellis trellis;
+			unsigned char payload[18U];
+			bool ret = trellis.decode(data + 2U, payload);
+			if (ret) {
+				::sprintf(title, "DMR Slot %u, Data 3/4", m_slotNo);
+				CUtils::dump(1U, title, payload, 18U);
+				trellis.encode(payload, data + 2U);
+			} else {
+				LogMessage("DMR Slot %u, unfixable network rate 3/4 data", m_slotNo);
+				CUtils::dump(1U, "Data", data + 2U, DMR_FRAME_LENGTH_BYTES);
+			}
+		}
+		else
+		{
+			::sprintf(title, "DMR Slot %u, Data 1/1", m_slotNo);
+			CUtils::dump(1U, title, data + 2U, 24U);
+		}
 
 
 		// Regenerate the Slot Type

--- a/DMRTrellis.cpp
+++ b/DMRTrellis.cpp
@@ -280,12 +280,12 @@ void CDMRTrellis::pointsToDibits(const unsigned char* points, signed char* dibit
 void CDMRTrellis::bitsToTribits(const unsigned char* payload, unsigned char* tribits) const
 {
 	for (unsigned int i = 0U; i < 48U; i++) {
-		unsigned int n = 143U - i * 3U;
+		unsigned int n = i * 3U;
 
 		bool b1 = READ_BIT(payload, n) != 0x00U;
-		n--;
+		n++;
 		bool b2 = READ_BIT(payload, n) != 0x00U;
-		n--;
+		n++;
 		bool b3 = READ_BIT(payload, n) != 0x00U;
 
 		unsigned char tribit = 0U;
@@ -308,12 +308,12 @@ void CDMRTrellis::tribitsToBits(const unsigned char* tribits, unsigned char* pay
 		bool b2 = (tribit & 0x02U) == 0x02U;
 		bool b3 = (tribit & 0x01U) == 0x01U;
 
-		unsigned int n = 143U - i * 3U;
+		unsigned int n = i * 3U;
 
 		WRITE_BIT(payload, n, b1);
-		n--;
+		n++;
 		WRITE_BIT(payload, n, b2);
-		n--;
+		n++;
 		WRITE_BIT(payload, n, b3);
 	}
 }


### PR DESCRIPTION
The trellis decoder and encoder are both working with reverse bit order. 
After this change I'm able to decode data packets with trellis encoding from my Hytera successfully. 

Fix #744 