### PR TITLE
add missing header file cstdint for using uint64_t and uint8_t

### DIFF
--- a/M17Utils.cpp
+++ b/M17Utils.cpp
@@ -19,6 +19,7 @@
 #include "M17Utils.h"
 #include "M17Defines.h"
 
+#include <cstdint>
 #include <cassert>
 
 const std::string M17_CHARS = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";

--- a/NullController.cpp
+++ b/NullController.cpp
@@ -19,6 +19,7 @@
 #include "NullController.h"
 
 #include <cstdio>
+#include <cstdint>
 #include <cassert>
 
 const unsigned char MMDVM_FRAME_START = 0xE0U;


### PR DESCRIPTION
M17Utils.cpp uses uint64_t
NullController.cpp uses uint8_t
but they do not include the cstdint header file, resulting in a compilation error.