### PR TITLE
replace CFLAGS -> LDFLAGS when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ OBJECTS = \
 all:		MMDVMHost RemoteCommand
 
 MMDVMHost:	GitVersion.h $(OBJECTS) 
-		$(CXX) $(OBJECTS) $(CFLAGS) $(LIBS) -o MMDVMHost
+		$(CXX) $(OBJECTS) $(LDFLAGS) $(LIBS) -o MMDVMHost
 
 RemoteCommand:	Log.o RemoteCommand.o UDPSocket.o
-		$(CXX) Log.o RemoteCommand.o UDPSocket.o $(CFLAGS) $(LIBS) -o RemoteCommand
+		$(CXX) Log.o RemoteCommand.o UDPSocket.o $(LDFLAGS) $(LIBS) -o RemoteCommand
 
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
linking /usr/**local**/lib/libsamplerate.a, need to use LDFLAGS.

```
c++ Log.o RemoteCommand.o UDPSocket.o -g -O3 -Wall -std=c++0x -pthread -DHAVE_LOG_H -I/usr/local/include -lpthread -lutil -lsamplerate -o RemoteCommand
ld: error: unable to find library -lsamplerate
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```
