### PR TITLE
TFTSurenoo: add 240x320 panel support

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -308,6 +308,7 @@ m_ax25NetworkSpeed(9600U),
 m_ax25NetworkDebug(false),
 m_tftSerialPort("/dev/ttyAMA0"),
 m_tftSerialBrightness(50U),
+m_tftSerialScreenLayout(0U),
 m_hd44780Rows(2U),
 m_hd44780Columns(16U),
 m_hd44780Pins(),
@@ -1073,6 +1074,8 @@ bool CConf::read()
 				m_tftSerialPort = value;
 			else if (::strcmp(key, "Brightness") == 0)
 				m_tftSerialBrightness = (unsigned int)::atoi(value);
+			else if (::strcmp(key, "ScreenLayout") == 0)
+				m_tftSerialScreenLayout = (unsigned int)::atoi(value);
 		} else if (section == SECTION_HD44780) {
 			if (::strcmp(key, "Rows") == 0)
 				m_hd44780Rows = (unsigned int)::atoi(value);
@@ -2367,6 +2370,11 @@ std::string CConf::getTFTSerialPort() const
 unsigned int CConf::getTFTSerialBrightness() const
 {
 	return m_tftSerialBrightness;
+}
+
+unsigned int CConf::getTFTSerialScreenLayout() const
+{
+	return m_tftSerialScreenLayout;
 }
 
 unsigned int CConf::getHD44780Rows() const

--- a/Conf.h
+++ b/Conf.h
@@ -325,6 +325,7 @@ public:
   // The TFTSERIAL section
   std::string  getTFTSerialPort() const;
   unsigned int getTFTSerialBrightness() const;
+  unsigned int getTFTSerialScreenLayout() const;
 
   // The HD44780 section
   unsigned int getHD44780Rows() const;
@@ -642,6 +643,7 @@ private:
 
   std::string  m_tftSerialPort;
   unsigned int m_tftSerialBrightness;
+  unsigned int m_tftSerialScreenLayout;
 
   unsigned int m_hd44780Rows;
   unsigned int m_hd44780Columns;

--- a/Display.cpp
+++ b/Display.cpp
@@ -553,9 +553,11 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CModem* modem)
 	if (type == "TFT Surenoo") {
 		std::string port        = conf.getTFTSerialPort();
 		unsigned int brightness = conf.getTFTSerialBrightness();
+		unsigned int screenLayout = conf.getTFTSerialScreenLayout();
 
 		LogInfo("    Port: %s", port.c_str());
 		LogInfo("    Brightness: %u", brightness);
+		LogInfo("    Screen Layout: %u", screenLayout);
 
 		ISerialPort* serial = NULL;
 		if (port == "modem")
@@ -563,7 +565,7 @@ CDisplay* CDisplay::createDisplay(const CConf& conf, CModem* modem)
 		else
 			serial = new CUARTController(port, 115200U);
 
-		display = new CTFTSurenoo(conf.getCallsign(), dmrid, serial, brightness, conf.getDuplex());
+		display = new CTFTSurenoo(conf.getCallsign(), dmrid, serial, brightness, conf.getDuplex(), screenLayout);
 	} else if (type == "Nextion") {
 		std::string port            = conf.getNextionPort();
 		unsigned int brightness     = conf.getNextionBrightness();

--- a/MMDVM.ini
+++ b/MMDVM.ini
@@ -314,6 +314,7 @@ Debug=0
 # Port=modem
 Port=/dev/ttyAMA0
 Brightness=50
+ScreenLayout=0
 
 [HD44780]
 Rows=2

--- a/TFTSurenoo.h
+++ b/TFTSurenoo.h
@@ -30,7 +30,7 @@
 class CTFTSurenoo : public CDisplay
 {
 public:
-	CTFTSurenoo(const std::string& callsign, unsigned int dmrid, ISerialPort* serial, unsigned int brightness, bool duplex);
+	CTFTSurenoo(const std::string& callsign, unsigned int dmrid, ISerialPort* serial, unsigned int brightness, bool duplex, unsigned int screenLayout);
 	virtual ~CTFTSurenoo();
 
 	virtual bool open();
@@ -83,6 +83,7 @@ private:
 	CTimer        m_refreshTimer;
 	char*         m_lineBuf;
 	char          m_temp[128];
+	unsigned int  m_screenLayout;
 
 	void setLineBuffer(char *buf, const char *text, int maxchar);
 	void setModeLine(const char *text);


### PR DESCRIPTION
to support 240x320 panel, add ScreenLayout property at [TFT Serial] section in MDVM.ini:

	ScreenLayout=0 160x128 (default)
	ScreenLayout=1 128x160
	ScreenLayout=2 320x240
	ScreenLayout=3 240x320

(landscape layout is recommended)