### PR TITLE
Avoid buffer overflow in Log.

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -164,10 +164,11 @@ void Log(unsigned int level, const char* fmt, ...)
 	::sprintf(buffer, "%c: %04d-%02d-%02d %02d:%02d:%02d.%03lld ", LEVELS[level], tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, now.tv_usec / 1000LL);
 #endif
 
+	size_t bufLen = ::strlen(buffer);
 	va_list vl;
 	va_start(vl, fmt);
 
-	::vsnprintf((buffer + ::strlen(buffer)), (500U - ::strlen(buffer)), fmt, vl);
+	::vsnprintf((buffer + bufLen), (500U - bufLen), fmt, vl);
 
 	va_end(vl);
 

--- a/Log.cpp
+++ b/Log.cpp
@@ -167,7 +167,7 @@ void Log(unsigned int level, const char* fmt, ...)
 	va_list vl;
 	va_start(vl, fmt);
 
-	::vsnprintf(buffer + ::strlen(buffer), 500, fmt, vl);
+	::vsnprintf((buffer + ::strlen(buffer)), (500U - ::strlen(buffer)), fmt, vl);
 
 	va_end(vl);
 


### PR DESCRIPTION
Avoid possible buffer overflow.
Fix instant crashing when compiled and run on LinuxMint (GCC 13.3) and probably many distro with recent toolchain. It seems I'm not the only one experiencing this problem:
```
*** buffer overflow detected ***: terminated
Aborted (core dumped)
```
It's identical to #811.