### PR TITLE
Some cleanups and fixes with modes enability.

### DIFF
--- a/DMRSlot.cpp
+++ b/DMRSlot.cpp
@@ -1870,6 +1870,9 @@ void CDMRSlot::clock()
 		}
 	}
 
+	if (!m_enabled)
+		return;
+
 	if ((m_netState == RPT_NET_STATE::AUDIO) || (m_netState == RPT_NET_STATE::DATA)) {
 		m_networkWatchdog.clock(ms);
 
@@ -2238,6 +2241,19 @@ void CDMRSlot::enable(bool enabled)
 		m_queue.clear();
 
 		// Reset the RF section
+		switch (m_rfState) {
+		case RPT_RF_STATE::LISTENING:
+		case RPT_RF_STATE::REJECTED:
+		case RPT_RF_STATE::INVALID:
+			break;
+
+		default:
+			if (m_rfTimeoutTimer.isRunning()) {
+				if (!m_rfTimeout)
+					LogMessage("DMR Slot %u, RF user has timed out", m_slotNo);
+			}
+			break;
+		}
 		m_rfState = RPT_RF_STATE::LISTENING;
 
 		m_rfTimeoutTimer.stop();
@@ -2254,6 +2270,17 @@ void CDMRSlot::enable(bool enabled)
 		m_rfLC = nullptr;
 
 		// Reset the networking section
+		switch(m_netState) {
+		case RPT_NET_STATE::IDLE:
+			break;
+
+		default:
+			if (m_netTimeoutTimer.isRunning()) {
+				if (!m_netTimeout)
+					LogMessage("DMR Slot %u, network user has timed out", m_slotNo);
+			}
+			break;
+		}
 		m_netState = RPT_NET_STATE::IDLE;
 
 		m_lastFrameValid = false;

--- a/DStarControl.cpp
+++ b/DStarControl.cpp
@@ -834,6 +834,9 @@ void CDStarControl::clock()
 	if (m_network != nullptr)
 		writeNetwork();
 
+	if (!m_enabled)
+		return;
+
 	m_ackTimer.clock(ms);
 	if (m_ackTimer.isRunning() && m_ackTimer.hasExpired()) {
 		sendAck();
@@ -1299,11 +1302,33 @@ void CDStarControl::enable(bool enabled)
 		m_queue.clear();
 
 		// Reset the RF section
+		switch (m_rfState) {
+		case RPT_RF_STATE::LISTENING:
+		case RPT_RF_STATE::REJECTED:
+		case RPT_RF_STATE::INVALID:
+			break;
+
+		default:
+			if (m_rfTimeoutTimer.isRunning()) {
+				LogMessage("D-Star, RF user has timed out");
+			}
+			break;
+		}
 		m_rfState = RPT_RF_STATE::LISTENING;
 
 		m_rfTimeoutTimer.stop();
 
 		// Reset the networking section
+		switch(m_netState) {
+		case RPT_NET_STATE::IDLE:
+			break;
+
+		default:
+			if (m_netTimeoutTimer.isRunning()) {
+				LogMessage("D-Star, network user has timed out");
+			}
+			break;
+		}
 		m_netState = RPT_NET_STATE::IDLE;
 
 		m_lastFrameValid = false;

--- a/M17Control.cpp
+++ b/M17Control.cpp
@@ -838,6 +838,9 @@ void CM17Control::clock(unsigned int ms)
 	if (m_network != nullptr)
 		writeNetwork();
 
+	if (!m_enabled)
+	  return;
+
 	m_rfTimeoutTimer.clock(ms);
 	m_netTimeoutTimer.clock(ms);
 
@@ -975,11 +978,33 @@ void CM17Control::enable(bool enabled)
 		m_queue.clear();
 
 		// Reset the RF section
+		switch (m_rfState) {
+		case RPT_RF_STATE::LISTENING:
+		case RPT_RF_STATE::REJECTED:
+		case RPT_RF_STATE::INVALID:
+			break;
+
+		default:
+			if (m_rfTimeoutTimer.isRunning()) {
+				LogMessage("M17, RF user has timed out");
+			}
+			break;
+		}
 		m_rfState = RPT_RF_STATE::LISTENING;
 
 		m_rfTimeoutTimer.stop();
 
 		// Reset the networking section
+		switch(m_netState) {
+		case RPT_NET_STATE::IDLE:
+			break;
+
+		default:
+			if (m_netTimeoutTimer.isRunning()) {
+				LogMessage("M17, network user has timed out");
+			}
+			break;
+		}
 		m_netState = RPT_NET_STATE::IDLE;
 
 		m_netTimeoutTimer.stop();

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -789,7 +789,7 @@ int CMMDVMHost::run()
 		bool ret;
 
 		len = m_modem->readDStarData(data);
-		if (m_dstar != nullptr && len > 0U) {
+		if (m_dstar != nullptr && m_dstarEnabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				bool ret = m_dstar->writeModem(data, len);
 				if (ret) {
@@ -806,7 +806,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readDMRData1(data);
-		if (m_dmr != nullptr && len > 0U) {
+		if (m_dmr != nullptr && m_dmrEnabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				if (m_duplex) {
 					bool ret = m_dmr->processWakeup(data);
@@ -843,7 +843,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readDMRData2(data);
-		if (m_dmr != nullptr && len > 0U) {
+		if (m_dmr != nullptr && m_dmrEnabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				if (m_duplex) {
 					bool ret = m_dmr->processWakeup(data);
@@ -880,7 +880,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readYSFData(data);
-		if (m_ysf != nullptr && len > 0U) {
+		if (m_ysf != nullptr && m_ysfEnabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				bool ret = m_ysf->writeModem(data, len);
 				if (ret) {
@@ -897,7 +897,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readP25Data(data);
-		if (m_p25 != nullptr && len > 0U) {
+		if (m_p25 != nullptr && m_p25Enabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				bool ret = m_p25->writeModem(data, len);
 				if (ret) {
@@ -914,7 +914,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readNXDNData(data);
-		if (m_nxdn != nullptr && len > 0U) {
+		if (m_nxdn != nullptr && m_nxdnEnabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				bool ret = m_nxdn->writeModem(data, len);
 				if (ret) {
@@ -931,7 +931,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readM17Data(data);
-		if (m_m17 != nullptr && len > 0U) {
+		if (m_m17 != nullptr && m_m17Enabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				bool ret = m_m17->writeModem(data, len);
 				if (ret) {
@@ -948,7 +948,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readFMData(data);
-		if (m_fm != nullptr && len > 0U) {
+		if (m_fm != nullptr && m_fmEnabled && len > 0U) {
 			if (m_mode == MODE_IDLE) {
 				bool ret = m_fm->writeModem(data, len);
 				if (ret) {
@@ -965,7 +965,7 @@ int CMMDVMHost::run()
 		}
 
 		len = m_modem->readAX25Data(data);
-		if (m_ax25 != nullptr && len > 0U) {
+		if (m_ax25 != nullptr && m_ax25Enabled && len > 0U) {
 			if (m_mode == MODE_IDLE || m_mode == MODE_FM) {
 				m_ax25->writeModem(data, len);
 			} else if (m_mode != MODE_LOCKOUT) {
@@ -982,7 +982,7 @@ int CMMDVMHost::run()
 				setMode(MODE_IDLE);
 		}
 
-		if (m_dstar != nullptr) {
+		if (m_dstar != nullptr && m_dstarEnabled) {
 			ret = m_modem->hasDStarSpace();
 			if (ret) {
 				len = m_dstar->readModem(data);
@@ -1001,7 +1001,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_dmr != nullptr) {
+		if (m_dmr != nullptr && m_dmrEnabled) {
 			ret = m_modem->hasDMRSpace1();
 			if (ret) {
 				len = m_dmr->readModemSlot1(data);
@@ -1047,7 +1047,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_ysf != nullptr) {
+		if (m_ysf != nullptr && m_ysfEnabled) {
 			ret = m_modem->hasYSFSpace();
 			if (ret) {
 				len = m_ysf->readModem(data);
@@ -1066,7 +1066,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_p25 != nullptr) {
+		if (m_p25 != nullptr && m_p25Enabled) {
 			ret = m_modem->hasP25Space();
 			if (ret) {
 				len = m_p25->readModem(data);
@@ -1085,7 +1085,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_nxdn != nullptr) {
+		if (m_nxdn != nullptr && m_nxdnEnabled) {
 			ret = m_modem->hasNXDNSpace();
 			if (ret) {
 				len = m_nxdn->readModem(data);
@@ -1104,7 +1104,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_m17 != nullptr) {
+		if (m_m17 != nullptr && m_m17Enabled) {
 			ret = m_modem->hasM17Space();
 			if (ret) {
 				len = m_m17->readModem(data);
@@ -1123,7 +1123,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_pocsag != nullptr) {
+		if (m_pocsag != nullptr && m_pocsagEnabled) {
 			ret = m_modem->hasPOCSAGSpace();
 			if (ret) {
 				len = m_pocsag->readModem(data);
@@ -1142,7 +1142,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_fm != nullptr) {
+		if (m_fm != nullptr && m_fmEnabled) {
 			unsigned int space = m_modem->getFMSpace();
 			if (space > 0U) {
 				len = m_fm->readModem(data, space);
@@ -1161,7 +1161,7 @@ int CMMDVMHost::run()
 			}
 		}
 
-		if (m_ax25 != nullptr) {
+		if (m_ax25 != nullptr && m_ax25Enabled) {
 			ret = m_modem->hasAX25Space();
 			if (ret) {
 				len = m_ax25->readModem(data);
@@ -1267,7 +1267,7 @@ int CMMDVMHost::run()
 				}
 				break;
 			case DMR_BEACONS::NETWORK:
-				if (m_dmrNetwork != nullptr) {
+				if (m_dmrNetwork != nullptr && m_dmrEnabled) {
 					bool beacon = m_dmrNetwork->wantsBeacon();
 					if (beacon) {
 						if ((m_mode == MODE_IDLE || m_mode == MODE_DMR) && !m_modem->hasTX()) {
@@ -1300,7 +1300,7 @@ int CMMDVMHost::run()
 		pocsagTimer.clock(ms);
 		if (pocsagTimer.isRunning() && pocsagTimer.hasExpired()) {
 			assert(m_pocsagNetwork != nullptr);
-			m_pocsagNetwork->enable(m_mode == MODE_IDLE || m_mode == MODE_POCSAG);
+			m_pocsagNetwork->enable((m_mode == MODE_IDLE || m_mode == MODE_POCSAG) && m_pocsagEnabled);
 			pocsagTimer.start();
 		}
 
@@ -1984,6 +1984,183 @@ void CMMDVMHost::readParams()
 	LogInfo("    AX.25: %s", m_ax25Enabled ? "enabled" : "disabled");
 }
 
+void CMMDVMHost::enableModemMode(bool& mode, bool enabled)
+{
+	LogDebug("Setting mode current=%s new=%s", mode ? "true" : "false", enabled ? "true" : "false");
+
+	mode = enabled;
+
+	m_modem->setModeParams(m_dstarEnabled, m_dmrEnabled, m_ysfEnabled, m_p25Enabled, m_nxdnEnabled, m_m17Enabled, m_pocsagEnabled, m_fmEnabled, m_ax25Enabled);
+	if (!m_modem->writeConfig())
+		LogError("Cannot write Config to MMDVM");
+}
+
+void CMMDVMHost::enableMode(unsigned char mode, bool hasController, bool& modeEnabled, bool isAX25)
+{
+	if (hasController && !modeEnabled) {
+		unsigned char data[500U];
+
+		// Try to recover ASAP when mode is currently set to IDLE,
+		// as Controller and Network will ::clock() immediatly after.
+		if (m_mode == MODE_IDLE) {
+			switch (mode) {
+			case MODE_DSTAR:
+				if (m_dstarNetwork != nullptr)
+					m_dstarNetwork->enable(true);
+				m_dstar->enable(true);
+				break;
+			case MODE_DMR:
+				if (m_dmrNetwork != nullptr)
+					m_dmrNetwork->enable(true);
+				m_dmr->enable(true);
+				break;
+			case MODE_YSF:
+				if (m_ysfNetwork != nullptr)
+					m_ysfNetwork->enable(true);
+				m_ysf->enable(true);
+				break;
+			case MODE_P25:
+				if (m_p25Network != nullptr)
+					m_p25Network->enable(true);
+				m_p25->enable(true);
+				break;
+			case MODE_NXDN:
+				if (m_nxdnNetwork != nullptr)
+					m_nxdnNetwork->enable(true);
+				m_nxdn->enable(true);
+				break;
+			case MODE_M17:
+				if (m_m17Network != nullptr)
+					m_m17Network->enable(true);
+				m_m17->enable(true);
+				break;
+			case MODE_FM:
+				if (isAX25)
+					m_ax25->enable(true);
+				else
+					m_fm->enable(true);
+				break;
+			default:
+				break;
+			}
+		}
+
+		// Flush modem data for the given mode
+		switch (mode) {
+		case MODE_DSTAR:
+			while (m_modem->readDStarData(data) > 0U);
+			break;
+		case MODE_DMR:
+			while (m_modem->readDMRData1(data) > 0U || m_modem->readDMRData2(data) > 0U);
+			break;
+		case MODE_YSF:
+			while (m_modem->readYSFData(data) > 0U);
+			break;
+		case MODE_P25:
+			while (m_modem->readP25Data(data) > 0U);
+			break;
+		case MODE_NXDN:
+			while (m_modem->readNXDNData(data) > 0U);
+			break;
+		case MODE_M17:
+			while (m_modem->readM17Data(data) > 0U);
+			break;
+		case MODE_FM:
+			while ((isAX25 ? m_modem->readAX25Data(data) : m_modem->readFMData(data)) > 0U);
+			break;
+		default:
+			break;
+		}
+
+		enableModemMode(modeEnabled, true);
+	}
+}
+
+void CMMDVMHost::disableMode(unsigned char mode, bool hasController, bool& modeEnabled, bool isAX25)
+{
+	if (hasController && modeEnabled) {
+		unsigned char data[500U];
+		bool switchToIDLE = (m_mode == mode);
+
+		// Disable Network and Controller
+		if (switchToIDLE) {
+			switch (mode) {
+			case MODE_DSTAR:
+				if (m_dstarNetwork != nullptr)
+					m_dstarNetwork->enable(false);
+				m_dstar->enable(false);
+				break;
+			case MODE_DMR:
+				if (m_dmrNetwork != nullptr)
+					m_dmrNetwork->enable(false);
+				m_dmr->enable(false);
+				break;
+			case MODE_YSF:
+				if (m_ysfNetwork != nullptr)
+					m_ysfNetwork->enable(false);
+				m_ysf->enable(false);
+				break;
+			case MODE_P25:
+				if (m_p25Network != nullptr)
+					m_p25Network->enable(false);
+				m_p25->enable(false);
+				break;
+			case MODE_NXDN:
+				if (m_nxdnNetwork != nullptr)
+					m_nxdnNetwork->enable(false);
+				m_nxdn->enable(false);
+				break;
+			case MODE_M17:
+				if (m_m17Network != nullptr)
+					m_m17Network->enable(false);
+				m_m17->enable(false);
+				break;
+			case MODE_FM:
+				if (isAX25) {
+					m_ax25->enable(false);
+				}
+				else {
+					m_fm->enable(false);
+				}
+				break;
+			default:
+				break;
+			}
+		}
+
+		// Flush modem data for the given mode
+		switch (mode) {
+		case MODE_DSTAR:
+			while (m_modem->readDStarData(data) > 0U);
+			break;
+		case MODE_DMR:
+			while (m_modem->readDMRData1(data) > 0U || m_modem->readDMRData2(data) > 0U);
+			break;
+		case MODE_YSF:
+			while (m_modem->readYSFData(data) > 0U);
+			break;
+		case MODE_P25:
+			while (m_modem->readP25Data(data) > 0U);
+			break;
+		case MODE_NXDN:
+			while (m_modem->readNXDNData(data) > 0U);
+			break;
+		case MODE_M17:
+			while (m_modem->readM17Data(data) > 0U);
+			break;
+		case MODE_FM:
+			while ((isAX25 ? m_modem->readAX25Data(data) : m_modem->readFMData(data)) > 0U);
+			break;
+		default:
+			break;
+		}
+
+		enableModemMode(modeEnabled, false);
+
+		if (switchToIDLE)
+			setMode(MODE_IDLE);
+	}
+}
 void CMMDVMHost::setMode(unsigned char mode)
 {
 	assert(m_modem != nullptr);
@@ -2289,7 +2466,7 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_nxdnNetwork->enable(false);
 		if (m_m17Network != nullptr)
 			m_m17Network->enable(false);
-		if (m_pocsagNetwork != nullptr)
+		if (m_pocsagNetwork != nullptr && m_pocsagEnabled)
 			m_pocsagNetwork->enable(true);
 		if (m_fmNetwork != nullptr)
 			m_fmNetwork->enable(false);
@@ -2307,7 +2484,7 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_nxdn->enable(false);
 		if (m_m17 != nullptr)
 			m_m17->enable(false);
-		if (m_pocsag != nullptr)
+		if (m_pocsag != nullptr && m_pocsagEnabled)
 			m_pocsag->enable(true);
 		if (m_fm != nullptr)
 			m_fm->enable(false);
@@ -2338,7 +2515,7 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_pocsagNetwork->enable(false);
 		if (m_fmNetwork != nullptr && m_fmEnabled)
 			m_fmNetwork->enable(true);
-		if (m_ax25Network != nullptr && m_fmEnabled)
+		if (m_ax25Network != nullptr && m_ax25Enabled)
 			m_ax25Network->enable(true);
 		if (m_dstar != nullptr)
 			m_dstar->enable(false);
@@ -2356,7 +2533,7 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_pocsag->enable(false);
 		if (m_fm != nullptr && m_fmEnabled)
 			m_fm->enable(true);
-		if (m_ax25 != nullptr && m_fmEnabled)
+		if (m_ax25 != nullptr && m_ax25Enabled)
 			m_ax25->enable(true);
 		if (m_mode == MODE_DMR && m_duplex && m_modem->hasTX()) {
 			m_modem->writeDMRStart(false);
@@ -2486,7 +2663,7 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_nxdnNetwork->enable(true);
 		if (m_m17Network != nullptr && m_m17Enabled)
 			m_m17Network->enable(true);
-		if (m_pocsagNetwork != nullptr)
+		if (m_pocsagNetwork != nullptr && m_pocsagEnabled)
 			m_pocsagNetwork->enable(true);
 		if (m_fmNetwork != nullptr && m_fmEnabled)
 			m_fmNetwork->enable(true);
@@ -2504,7 +2681,7 @@ void CMMDVMHost::setMode(unsigned char mode)
 			m_nxdn->enable(true);
 		if (m_m17 != nullptr && m_m17Enabled)
 			m_m17->enable(true);
-		if (m_pocsag != nullptr)
+		if (m_pocsag != nullptr && m_pocsagEnabled)
 			m_pocsag->enable(true);
 		if (m_fm != nullptr && m_fmEnabled)
 			m_fm->enable(true);
@@ -2559,213 +2736,149 @@ void CMMDVMHost::remoteControl()
 	REMOTE_COMMAND command = m_remoteControl->getCommand();
 	switch (command) {
 	case REMOTE_COMMAND::MODE_IDLE:
-			m_fixedMode = false;
-			setMode(MODE_IDLE);
-			break;
-		case REMOTE_COMMAND::MODE_LOCKOUT:
-			m_fixedMode = false;
-			setMode(MODE_LOCKOUT);
-			break;
-		case REMOTE_COMMAND::MODE_DSTAR:
-			if (m_dstar != nullptr)
-				processModeCommand(MODE_DSTAR, m_dstarRFModeHang);
-			break;
-		case REMOTE_COMMAND::MODE_DMR:
-			if (m_dmr != nullptr)
-				processModeCommand(MODE_DMR, m_dmrRFModeHang);
-			break;
-		case REMOTE_COMMAND::MODE_YSF:
-			if (m_ysf != nullptr)
-				processModeCommand(MODE_YSF, m_ysfRFModeHang);
-			break;
-		case REMOTE_COMMAND::MODE_P25:
-			if (m_p25 != nullptr)
-				processModeCommand(MODE_P25, m_p25RFModeHang);
-			break;
-		case REMOTE_COMMAND::MODE_NXDN:
-			if (m_nxdn != nullptr)
-				processModeCommand(MODE_NXDN, m_nxdnRFModeHang);
-			break;
-		case REMOTE_COMMAND::MODE_M17:
-			if (m_m17 != nullptr)
-				processModeCommand(MODE_M17, m_m17RFModeHang);
-			break;
-		case REMOTE_COMMAND::MODE_FM:
-			if (m_fmEnabled)
-				processModeCommand(MODE_FM, 0);
-			break;
-		case REMOTE_COMMAND::ENABLE_DSTAR:
-			if (m_dstar != nullptr && !m_dstarEnabled)
-				processEnableCommand(m_dstarEnabled, true);
-			if (m_dstarNetwork != nullptr)
-				m_dstarNetwork->enable(true);
-			break;
-		case REMOTE_COMMAND::ENABLE_DMR:
-			if (m_dmr != nullptr && !m_dmrEnabled)
-				processEnableCommand(m_dmrEnabled, true);
-			if (m_dmrNetwork != nullptr)
-				m_dmrNetwork->enable(true);
-			break;
-		case REMOTE_COMMAND::ENABLE_YSF:
-			if (m_ysf != nullptr && !m_ysfEnabled)
-				processEnableCommand(m_ysfEnabled, true);
-			if (m_ysfNetwork != nullptr)
-				m_ysfNetwork->enable(true);
-			break;
-		case REMOTE_COMMAND::ENABLE_P25:
-			if (m_p25 != nullptr && !m_p25Enabled)
-				processEnableCommand(m_p25Enabled, true);
-			if (m_p25Network != nullptr)
-				m_p25Network->enable(true);
-			break;
-		case REMOTE_COMMAND::ENABLE_NXDN:
-			if (m_nxdn != nullptr && !m_nxdnEnabled)
-				processEnableCommand(m_nxdnEnabled, true);
-			if (m_nxdnNetwork != nullptr)
-				m_nxdnNetwork->enable(true);
-			break;
-		case REMOTE_COMMAND::ENABLE_M17:
-			if (m_m17 != nullptr && !m_m17Enabled)
-				processEnableCommand(m_m17Enabled, true);
-			if (m_m17Network != nullptr)
-				m_m17Network->enable(true);
-			break;
-		case REMOTE_COMMAND::ENABLE_FM:
-			if (!m_fmEnabled)
-				processEnableCommand(m_fmEnabled, true);
-			break;
-		case REMOTE_COMMAND::ENABLE_AX25:
-			if (!m_ax25Enabled)
-				processEnableCommand(m_ax25Enabled, true);
-			break;
-		case REMOTE_COMMAND::DISABLE_DSTAR:
-			if (m_dstar != nullptr && m_dstarEnabled) {
-				if (m_mode == MODE_DSTAR)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_dstarEnabled, false);
+		m_fixedMode = false;
+		setMode(MODE_IDLE);
+		break;
+	case REMOTE_COMMAND::MODE_LOCKOUT:
+		m_fixedMode = false;
+		setMode(MODE_LOCKOUT);
+		break;
+	case REMOTE_COMMAND::MODE_DSTAR:
+		if (m_dstar != nullptr)
+			processModeCommand(MODE_DSTAR, m_dstarRFModeHang);
+		break;
+	case REMOTE_COMMAND::MODE_DMR:
+		if (m_dmr != nullptr)
+			processModeCommand(MODE_DMR, m_dmrRFModeHang);
+		break;
+	case REMOTE_COMMAND::MODE_YSF:
+		if (m_ysf != nullptr)
+			processModeCommand(MODE_YSF, m_ysfRFModeHang);
+		break;
+	case REMOTE_COMMAND::MODE_P25:
+		if (m_p25 != nullptr)
+			processModeCommand(MODE_P25, m_p25RFModeHang);
+		break;
+	case REMOTE_COMMAND::MODE_NXDN:
+		if (m_nxdn != nullptr)
+			processModeCommand(MODE_NXDN, m_nxdnRFModeHang);
+		break;
+	case REMOTE_COMMAND::MODE_M17:
+		if (m_m17 != nullptr)
+			processModeCommand(MODE_M17, m_m17RFModeHang);
+		break;
+	case REMOTE_COMMAND::MODE_FM:
+		if (m_fmEnabled)
+			processModeCommand(MODE_FM, 0);
+		break;
+	case REMOTE_COMMAND::ENABLE_DSTAR:
+		enableMode(MODE_DSTAR, (m_dstar != nullptr), m_dstarEnabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_DMR:
+		enableMode(MODE_DMR, (m_dmr != nullptr), m_dmrEnabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_YSF:
+		enableMode(MODE_YSF, (m_ysf != nullptr), m_ysfEnabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_P25:
+		enableMode(MODE_P25, (m_p25 != nullptr), m_p25Enabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_NXDN:
+		enableMode(MODE_NXDN, (m_nxdn != nullptr), m_nxdnEnabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_M17:
+		enableMode(MODE_M17, (m_m17 != nullptr), m_m17Enabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_FM:
+		enableMode(MODE_FM, (m_fm != nullptr), m_fmEnabled);
+		break;
+	case REMOTE_COMMAND::ENABLE_AX25:
+		enableMode(MODE_FM, (m_ax25 != nullptr), m_ax25Enabled, true);
+		break;
+	case REMOTE_COMMAND::DISABLE_DSTAR:
+		disableMode(MODE_DSTAR, (m_dstar != nullptr), m_dstarEnabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_DMR:
+		disableMode(MODE_DMR, (m_dmr != nullptr), m_dmrEnabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_YSF:
+		disableMode(MODE_YSF, (m_ysf != nullptr), m_ysfEnabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_P25:
+		disableMode(MODE_P25, (m_p25), m_p25Enabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_NXDN:
+		disableMode(MODE_NXDN, (m_nxdn != nullptr), m_nxdnEnabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_M17:
+		disableMode(MODE_M17, (m_m17 != nullptr), m_m17Enabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_FM:
+		disableMode(MODE_FM, (m_fm != nullptr), m_fmEnabled);
+		break;
+	case REMOTE_COMMAND::DISABLE_AX25:
+		disableMode(MODE_FM, (m_ax25 != nullptr), m_ax25Enabled, true);
+		break;
+	case REMOTE_COMMAND::PAGE:
+		if (m_pocsag != nullptr) {
+			unsigned int ric = m_remoteControl->getArgUInt(0U);
+			std::string text;
+			for (unsigned int i = 1U; i < m_remoteControl->getArgCount(); i++) {
+				if (i > 1U)
+					text += " ";
+				text += m_remoteControl->getArgString(i);
 			}
-			if (m_dstarNetwork != nullptr)
-				m_dstarNetwork->enable(false);
-			break;
-		case REMOTE_COMMAND::DISABLE_DMR:
-			if (m_dmr != nullptr && m_dmrEnabled) {
-				if (m_mode == MODE_DMR)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_dmrEnabled, false);
+			m_pocsag->sendPage(ric, text);
+		}
+		break;
+	case REMOTE_COMMAND::PAGE_BCD:
+		if (m_pocsag != nullptr) {
+			unsigned int ric = m_remoteControl->getArgUInt(0U);
+			std::string text;
+			for (unsigned int i = 1U; i < m_remoteControl->getArgCount(); i++) {
+				if (i > 1U)
+					text += " ";
+				text += m_remoteControl->getArgString(i);
 			}
-			if (m_dmrNetwork != nullptr)
-				m_dmrNetwork->enable(false);
-			break;
-		case REMOTE_COMMAND::DISABLE_YSF:
-			if (m_ysf != nullptr && m_ysfEnabled) {
-				if (m_mode == MODE_YSF)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_ysfEnabled, false);
+			m_pocsag->sendPageBCD(ric, text);
+		}
+		break;
+	case REMOTE_COMMAND::PAGE_A1:
+		if (m_pocsag != nullptr) {
+			unsigned int ric = m_remoteControl->getArgUInt(0U);
+			m_pocsag->sendPageAlert1(ric);
+		}
+		break;
+	case REMOTE_COMMAND::PAGE_A2:
+		if (m_pocsag != nullptr) {
+			unsigned int ric = m_remoteControl->getArgUInt(0U);
+			std::string text;
+			for (unsigned int i = 1U; i < m_remoteControl->getArgCount(); i++) {
+				if (i > 1U)
+					text += " ";
+				text += m_remoteControl->getArgString(i);
 			}
-			if (m_ysfNetwork != nullptr)
-				m_ysfNetwork->enable(false);
-			break;
-		case REMOTE_COMMAND::DISABLE_P25:
-			if (m_p25 != nullptr && m_p25Enabled) {
-				if (m_mode == MODE_P25)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_p25Enabled, false);
+			m_pocsag->sendPageAlert2(ric, text);
+		}
+		break;
+	case REMOTE_COMMAND::CW:
+		setMode(MODE_IDLE); // Force the modem to go idle so that we can send the CW text.
+		if (!m_modem->hasTX()) {
+			std::string cwtext;
+			for (unsigned int i = 0U; i < m_remoteControl->getArgCount(); i++) {
+				if (i > 0U)
+					cwtext += " ";
+				cwtext += m_remoteControl->getArgString(i);
 			}
-			if (m_p25Network != nullptr)
-				m_p25Network->enable(false);
-			break;
-		case REMOTE_COMMAND::DISABLE_NXDN:
-			if (m_nxdn != nullptr && m_nxdnEnabled) {
-				if (m_mode == MODE_NXDN)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_nxdnEnabled, false);
-			}
-			if (m_nxdnNetwork != nullptr)
-				m_nxdnNetwork->enable(false);
-			break;
-		case REMOTE_COMMAND::DISABLE_M17:
-			if (m_m17 != nullptr && m_m17Enabled) {
-				if (m_mode == MODE_M17)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_m17Enabled, false);
-			}
-			if (m_m17Network != nullptr)
-				m_m17Network->enable(false);
-			break;
-		case REMOTE_COMMAND::DISABLE_FM:
-			if (m_fmEnabled) {
-				if (m_mode == MODE_FM)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_fmEnabled, false);
-			}
-			break;
-		case REMOTE_COMMAND::DISABLE_AX25:
-			if (m_ax25Enabled == true) {
-				if (m_mode == MODE_FM)
-					setMode(MODE_IDLE);
-				processEnableCommand(m_ax25Enabled, false);
-			}
-			break;
-		case REMOTE_COMMAND::PAGE:
-			if (m_pocsag != nullptr) {
-				unsigned int ric = m_remoteControl->getArgUInt(0U);
-				std::string text;
-				for (unsigned int i = 1U; i < m_remoteControl->getArgCount(); i++) {
-					if (i > 1U)
-						text += " ";
-					text += m_remoteControl->getArgString(i);
-				}
-				m_pocsag->sendPage(ric, text);
-			}
-			break;
-		case REMOTE_COMMAND::PAGE_BCD:
-			if (m_pocsag != nullptr) {
-				unsigned int ric = m_remoteControl->getArgUInt(0U);
-				std::string text;
-				for (unsigned int i = 1U; i < m_remoteControl->getArgCount(); i++) {
-					if (i > 1U)
-						text += " ";
-					text += m_remoteControl->getArgString(i);
-				}
-				m_pocsag->sendPageBCD(ric, text);
-			}
-			break;
-		case REMOTE_COMMAND::PAGE_A1:
-			if (m_pocsag != nullptr) {
-				unsigned int ric = m_remoteControl->getArgUInt(0U);
-				m_pocsag->sendPageAlert1(ric);
-			}
-			break;
-		case REMOTE_COMMAND::PAGE_A2:
-			if (m_pocsag != nullptr) {
-				unsigned int ric = m_remoteControl->getArgUInt(0U);
-				std::string text;
-				for (unsigned int i = 1U; i < m_remoteControl->getArgCount(); i++) {
-					if (i > 1U)
-						text += " ";
-					text += m_remoteControl->getArgString(i);
-				}
-				m_pocsag->sendPageAlert2(ric, text);
-			}
-			break;
-		case REMOTE_COMMAND::CW:
-			setMode(MODE_IDLE); // Force the modem to go idle so that we can send the CW text.
-			if (!m_modem->hasTX()) {
-				std::string cwtext;
-				for (unsigned int i = 0U; i < m_remoteControl->getArgCount(); i++) {
-					if (i > 0U)
-						cwtext += " ";
-					cwtext += m_remoteControl->getArgString(i);
-				}
-				m_display->writeCW();
-				m_modem->sendCWId(cwtext);
-			}
-			break;
-		case REMOTE_COMMAND::RELOAD:
-			m_reload = true;
-			break;
-		default:
-			break;
+			m_display->writeCW();
+			m_modem->sendCWId(cwtext);
+		}
+		break;
+	case REMOTE_COMMAND::RELOAD:
+		m_reload = true;
+		break;
+	default:
+		break;
 	}
 }
 
@@ -2785,17 +2898,6 @@ void CMMDVMHost::processModeCommand(unsigned char mode, unsigned int timeout)
 	}
 
 	setMode(mode);
-}
-
-void CMMDVMHost::processEnableCommand(bool& mode, bool enabled)
-{
-	LogDebug("Setting mode current=%s new=%s",mode ? "true" : "false",enabled ? "true" : "false");
-
-	mode = enabled;
-
-	m_modem->setModeParams(m_dstarEnabled, m_dmrEnabled, m_ysfEnabled, m_p25Enabled, m_nxdnEnabled, m_m17Enabled, m_pocsagEnabled, m_fmEnabled, m_ax25Enabled);
-	if (!m_modem->writeConfig())
-		LogError("Cannot write Config to MMDVM");
 }
 
 void CMMDVMHost::buildNetworkStatusString(std::string &str)

--- a/MMDVMHost.h
+++ b/MMDVMHost.h
@@ -139,8 +139,7 @@ private:
 
   void setMode(unsigned char mode);
   void enableModemMode(bool& mode, bool enabled);
-  void enableMode(unsigned char mode, bool hasController, bool& modeEnabled, bool isAX25 = false);
-  void disableMode(unsigned char mode, bool hasController, bool& modeEnabled, bool isAX25 = false);
+  void processEnableModeCommand(unsigned char mode, bool hasController, bool& modeEnabled, bool enableMode, bool isAX25 = false);
 
   void createLockFile(const char* mode) const;
   void removeLockFile() const;

--- a/MMDVMHost.h
+++ b/MMDVMHost.h
@@ -136,9 +136,11 @@ private:
 
   void remoteControl();
   void processModeCommand(unsigned char mode, unsigned int timeout);
-  void processEnableCommand(bool& mode, bool enabled);
 
   void setMode(unsigned char mode);
+  void enableModemMode(bool& mode, bool enabled);
+  void enableMode(unsigned char mode, bool hasController, bool& modeEnabled, bool isAX25 = false);
+  void disableMode(unsigned char mode, bool hasController, bool& modeEnabled, bool isAX25 = false);
 
   void createLockFile(const char* mode) const;
   void removeLockFile() const;

--- a/Version.h
+++ b/Version.h
@@ -19,6 +19,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20250424";
+const char* VERSION = "20250529";
 
 #endif

--- a/YSFControl.cpp
+++ b/YSFControl.cpp
@@ -1057,6 +1057,9 @@ void CYSFControl::clock(unsigned int ms)
 	if (m_network != nullptr)
 		writeNetwork();
 
+	if (!m_enabled)
+		return;
+
 	m_rfTimeoutTimer.clock(ms);
 	m_netTimeoutTimer.clock(ms);
 
@@ -1206,6 +1209,18 @@ void CYSFControl::enable(bool enabled)
 		m_queue.clear();
 
 		// Reset the RF section
+		switch (m_rfState) {
+		case RPT_RF_STATE::LISTENING:
+		case RPT_RF_STATE::REJECTED:
+		case RPT_RF_STATE::INVALID:
+			break;
+
+		default:
+			if (m_rfTimeoutTimer.isRunning()) {
+				LogMessage("YSF, RF user has timed out");
+			}
+			break;
+		}
 		m_rfState = RPT_RF_STATE::LISTENING;
 
 		m_rfTimeoutTimer.stop();
@@ -1216,6 +1231,16 @@ void CYSFControl::enable(bool enabled)
 		m_rfDest   = nullptr;
 
 		// Reset the networking section
+		switch(m_netState) {
+		case RPT_NET_STATE::IDLE:
+			break;
+
+		default:
+			if (m_netTimeoutTimer.isRunning()) {
+				LogMessage("YSF, network user has timed out");
+			}
+			break;
+		}
 		m_netState = RPT_NET_STATE::IDLE;
 
 		m_netTimeoutTimer.stop();


### PR DESCRIPTION
CDMRSlot::clock(),
CDStarControl::clock(),
CM17Control::clock(),
CNXDNControl::clock(),
CP25Control::clock(),
CYSFControl::clock():
  - Leave ASAP when it's disabled.


CDMRSlot::enable(),
CDStarControl::enable(),
CM17Control::enable(),
CNXDNControl::enable(),
CP25Control::enable(),
CYSFControl::enable():
  - Log a message when Controller get disabled while running, "<MODE>, RF user has timed out" or "<MODE>, network user has timed out", depending of the RF/Net state.


CMMDVMHost::run():
  - After getting the modem data, don't handle it (read/write<Controler>, etc) if the given mode is not enabled.


MMDVMHost:
  - Rename CMMDVMHost::processEnableCommand() to CMMDVMHost::enableModemMode().
  - Add CMMDVMHost::processEnableModeCommand(), called it from CMMDVMHost::remoteControl(), which clarify the code.
  - CMMDVMHost::remoteControl():
    * Fix indentation,
    * Simplify ENABLE_x/DISABLE_x cases code.
  - CMMDVMHost::setMode():
    * Enable pocsag network only if m_pocsagEnabled is true,
    * Enable ax25 network only if m_ax25Enabled is true (not m_fmEnabled).