### PR TITLE
Fix Windows build (few warnings and a wrong file descriptor comparison).

### DIFF
--- a/LCDproc.cpp
+++ b/LCDproc.cpp
@@ -161,7 +161,11 @@ bool CLCDproc::open()
 
 	/* Create TCP socket */
 	m_socketfd = socket(clientAddress.ss_family, SOCK_STREAM, 0);
+#if defined(_WIN32) || defined(_WIN64)
+	if (m_socketfd == INVALID_SOCKET) {
+#else
 	if (m_socketfd == -1) {
+#endif
 		LogError("LCDproc, failed to create socket");
 		return false;
 	}

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -1402,7 +1402,9 @@ bool CMMDVMHost::createModem()
 	std::string uartPort         = m_conf.getModemUARTPort();
 	unsigned int uartSpeed       = m_conf.getModemUARTSpeed();
 	std::string i2cPort          = m_conf.getModemI2CPort();
+#if defined(__linux__)
 	unsigned int i2cAddress      = m_conf.getModemI2CAddress();
+#endif
 	std::string modemAddress     = m_conf.getModemModemAddress();
 	unsigned short modemPort     = m_conf.getModemModemPort();
 	std::string localAddress     = m_conf.getModemLocalAddress();


### PR DESCRIPTION
Add a Makefile to build while on MinGW32 (and probably w64) and DOS (using mingw32 toolchain).