### PR TITLE
Fix missing NXDN Net config entry handling and wrong getaddrinfo() argument.

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -993,6 +993,8 @@ bool CConf::read()
 		} else if (section == SECTION::NXDN_NETWORK) {
 			if (::strcmp(key, "Enable") == 0)
 				m_nxdnNetworkEnabled = ::atoi(value) == 1;
+			else if (::strcmp(key, "Protocol") == 0)
+				m_nxdnNetworkProtocol = value;
 			else if (::strcmp(key, "LocalAddress") == 0)
 				m_nxdnLocalAddress = value;
 			else if (::strcmp(key, "LocalPort") == 0)

--- a/UDPSocket.cpp
+++ b/UDPSocket.cpp
@@ -94,7 +94,7 @@ int CUDPSocket::lookup(const std::string& hostname, unsigned short port, sockadd
 	/* Port is always digits, no needs to lookup service */
 	hints.ai_flags |= AI_NUMERICSERV;
 
-	int err = ::getaddrinfo(hostname.empty() ? nullptr : hostname.c_str(), portstr.c_str(), &hints, &res);
+	int err = ::getaddrinfo(hostname.empty() ? NULL : hostname.c_str(), portstr.c_str(), &hints, &res);
 	if (err != 0) {
 		sockaddr_in* paddr = (sockaddr_in*)&addr;
 		::memset(paddr, 0x00U, address_length = sizeof(sockaddr_in));

--- a/Version.h
+++ b/Version.h
@@ -19,6 +19,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20250529";
+const char* VERSION = "20250607";
 
 #endif


### PR DESCRIPTION
  - Reintroduce [NXDN Network]::Protocol config item, as it got deleted at some point.
  - Fix nullptr instead of NULL argument usage in getaddrinfo().
  - Bump version.