### PR TITLE
Fix typo: MQTT_QOS_AT_MOST_ONCE

### DIFF
--- a/MQTTConnection.h
+++ b/MQTTConnection.h
@@ -25,7 +25,7 @@
 #include <string>
 
 enum MQTT_QOS {
-	MQTT_QOS_AT_MODE_ONCE  = 0U,
+	MQTT_QOS_AT_MOST_ONCE  = 0U,
 	MQTT_QOS_AT_LEAST_ONCE = 1U,
 	MQTT_QOS_EXACTLY_ONCE  = 2U
 };


### PR DESCRIPTION
Hi Jonathan, 

Just a simple typo fix. 
While perusing the source code I found a small typo in the MQTT QoS definitions.