### PR TITLE
MMDVMHost Nextion Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ RemoteCommand
 *.user
 *.VC.db
 .vs
+.vscode
 *.ambe
 GitVersion.h

--- a/Modem.h
+++ b/Modem.h
@@ -267,6 +267,10 @@ private:
 	void printDebug();
 
 	RESP_TYPE_MMDVM getResponse();
+
+	// Added these for buffering serial data from display:
+    unsigned char              m_serialDataBuffer[256];
+    unsigned int               m_serialDataLen;
 };
 
 #endif


### PR DESCRIPTION
This PR makes the following changes:
VSCode added to the .gitignore, just happens to be the IDE I use and I don't want it to puke additional garbage into GitHub.
Added a buffer to capture Nextion Screen commands coming from the screen (button pushes) and then send them to NextionDriver. This is a long standing one, and I am sure you'll be happy to see this.

Please *DO* review this code, I believe it to be written correctly, it has a length check that should avoid buffer over-run.
It may not look correct that it puts the data into m_rxTransparentData, but this really is correct.

The 256 length check and 260 buffer size might need future adjustment for LONG commands from the screen, who knows what wild things people had that doing, it will log some output if those are over-run.

Fix for: 796