### PR TITLE
Fix modem initialization sequence and MBC_CONTINUATION parsing

### DIFF
--- a/DMRCSBK.cpp
+++ b/DMRCSBK.cpp
@@ -75,6 +75,9 @@ bool CDMRCSBK::put(const unsigned char* bytes)
 		m_data[11U] ^= MBC_CRC_MASK[1U];
 		break;
 
+	case DT_MBC_CONTINUATION:
+		break;
+
 	default:
 		LogError("Unknown DMR CSBK data type: 0x%02X", m_dataType);
 		return false;
@@ -94,6 +97,9 @@ bool CDMRCSBK::put(const unsigned char* bytes)
 	case DT_MBC_HEADER:
 		m_data[10U] ^= MBC_CRC_MASK[0U];
 		m_data[11U] ^= MBC_CRC_MASK[1U];
+		break;
+
+	case DT_MBC_CONTINUATION:
 		break;
 
 	default:

--- a/MMDVMHost.cpp
+++ b/MMDVMHost.cpp
@@ -723,11 +723,8 @@ int CMMDVMHost::run()
 
 		// Tier III options
 		if (trunking) {
-			setMode(MODE_DMR);
-
-			m_modem->setDMRTrunkingParams(controlChannel);
 			m_modem->setDMRShortLC(systemCode, controlChannel, registrationRequired);
-
+			setMode(MODE_DMR);
 			if (controlChannel)
 				m_modem->writeDMRAloha(systemCode, registrationRequired, alternateSlot);
 		}
@@ -1575,6 +1572,8 @@ bool CMMDVMHost::createModem()
 	bool debug                   = m_conf.getModemDebug();
 #if defined(USE_DMR)
 	unsigned int colorCode       = m_conf.getDMRColorCode();
+	bool trunking                = m_conf.getDMRTrunkingEnabled();
+	bool controlChannel          = m_conf.getDMRControlChannel();
 #endif
 #if defined(USE_YSF)
 	bool lowDeviation            = m_conf.getFusionLowDeviation();
@@ -1680,6 +1679,8 @@ bool CMMDVMHost::createModem()
 	m_modem->setRFParams(rxFrequency, rxOffset, txFrequency, txOffset, txDCOffset, rxDCOffset, rfLevel, pocsagFrequency);
 #if defined(USE_DMR)
 	m_modem->setDMRParams(colorCode);
+	if(trunking)
+		m_modem->setDMRTrunkingParams(controlChannel);
 #endif
 #if defined(USE_YSF)
 	m_modem->setYSFParams(lowDeviation, ysfTXHang);


### PR DESCRIPTION
When the config is written to the MMDVM modem, the byte which enables the trunking logic in MMDVM was not set at the time of the modem opening, so trunking logic was not enabled. This change fixes the initialization order, and also allows MBC_CONTINUATION CSBK to be parsed without failing early.