### PR TITLE
P25: optionally send the caller callsign as a Motorola Soft ID

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -216,6 +216,7 @@ m_p25NAC(0x293U),
 m_p25SelfOnly(false),
 m_p25OverrideUID(false),
 m_p25RemoteGateway(false),
+m_p25SoftId(false),
 m_p25TXHang(5U),
 #endif
 m_p25ModeHang(10U),
@@ -836,6 +837,8 @@ bool CConf::read()
 				m_p25SelfOnly = ::atoi(value) == 1;
 			else if (::strcmp(key, "RemoteGateway") == 0)
 				m_p25RemoteGateway = ::atoi(value) == 1;
+			else if (::strcmp(key, "SoftId") == 0)
+				m_p25SoftId = ::atoi(value) == 1;
 			else if (::strcmp(key, "TXHang") == 0)
 				m_p25TXHang = (unsigned int)::atoi(value);
 			else if (::strcmp(key, "ModeHang") == 0)
@@ -1664,6 +1667,11 @@ bool CConf::getP25SelfOnly() const
 bool CConf::getP25RemoteGateway() const
 {
 	return m_p25RemoteGateway;
+}
+
+bool CConf::getP25SoftId() const
+{
+	return m_p25SoftId;
 }
 
 unsigned int CConf::getP25TXHang() const

--- a/Conf.h
+++ b/Conf.h
@@ -189,6 +189,7 @@ public:
 	bool         getP25SelfOnly() const;
 	bool         getP25OverrideUID() const;
 	bool         getP25RemoteGateway() const;
+	bool         getP25SoftId() const;
 	unsigned int getP25TXHang() const;
 	unsigned int getP25ModeHang() const;
 #endif
@@ -481,6 +482,7 @@ private:
 	bool         m_p25SelfOnly;
 	bool         m_p25OverrideUID;
 	bool         m_p25RemoteGateway;
+	bool         m_p25SoftId;
 	unsigned int m_p25TXHang;
 #endif
 	unsigned int m_p25ModeHang;

--- a/MMDVM-Host.cpp
+++ b/MMDVM-Host.cpp
@@ -760,6 +760,7 @@ int CMMDVMHost::run()
 		bool uidOverride    = m_conf.getP25OverrideUID();
 		bool selfOnly       = m_conf.getP25SelfOnly();
 		bool remoteGateway  = m_conf.getP25RemoteGateway();
+		bool softId         = m_conf.getP25SoftId();
 		m_p25RFModeHang     = m_conf.getP25ModeHang();
 
 		LogInfo("P25 RF Parameters");
@@ -768,10 +769,11 @@ int CMMDVMHost::run()
 		LogInfo("    UID Override: %s", uidOverride ? "yes" : "no");
 		LogInfo("    Self Only: %s", selfOnly ? "yes" : "no");
 		LogInfo("    Remote Gateway: %s", remoteGateway ? "yes" : "no");
+		LogInfo("    Soft ID: %s", softId ? "yes" : "no");
 		LogInfo("    TX Hang: %us", txHang);
 		LogInfo("    Mode Hang: %us", m_p25RFModeHang);
 
-		m_p25 = new CP25Control(nac, id, selfOnly, uidOverride, m_p25Network, m_timeout, m_duplex, m_dmrLookup, remoteGateway, rssi);
+		m_p25 = new CP25Control(nac, id, selfOnly, uidOverride, m_p25Network, m_timeout, m_duplex, m_dmrLookup, remoteGateway, softId, rssi);
 	}
 #endif
 

--- a/MMDVM-Host.ini
+++ b/MMDVM-Host.ini
@@ -139,6 +139,7 @@ NAC=293
 SelfOnly=0
 OverrideUIDCheck=0
 RemoteGateway=0
+SoftId=0
 TXHang=5
 # ModeHang=10
 

--- a/P25Control.cpp
+++ b/P25Control.cpp
@@ -41,7 +41,43 @@ const unsigned char BIT_MASK_TABLE[] = {0x80U, 0x40U, 0x20U, 0x10U, 0x08U, 0x04U
 #define WRITE_BIT(p,i,b) p[(i)>>3] = (b) ? (p[(i)>>3] | BIT_MASK_TABLE[(i)&7]) : (p[(i)>>3] & ~BIT_MASK_TABLE[(i)&7])
 #define READ_BIT(p,i)    (p[(i)>>3] & BIT_MASK_TABLE[(i)&7])
 
-CP25Control::CP25Control(unsigned int nac, unsigned int id, bool selfOnly, bool uidOverride, CP25Network* network, unsigned int timeout, bool duplex, CDMRLookup* lookup, bool remoteGateway, CRSSIInterpolator* rssiMapper) :
+// The Motorola "Soft ID" is an eight character alias carried in the low speed
+// data, two bytes per LDU, as opcode 0x02, length 0x08, the space padded text
+// and a two byte checksum. Motorola radios display it as the caller's name, and
+// reject the string outright if the checksum is wrong.
+//
+// Both checksum bytes are GF(256) lanes modulo x^8+x^4+x^3+x^2+1, where a
+// character contributes its position weight multiplied by the character. The
+// weights and the value for an all spaces string were measured off air.
+const unsigned char SOFT_ID_WEIGHT_HIGH[] = {0x88U, 0x62U, 0xB6U, 0xB3U, 0xEDU, 0x78U, 0x1CU, 0x06U};
+const unsigned char SOFT_ID_WEIGHT_LOW[]  = {0x37U, 0xD9U, 0xF1U, 0x3BU, 0xE7U, 0xE0U, 0x30U, 0x08U};
+
+const unsigned char SOFT_ID_BASE_HIGH = 0x81U;
+const unsigned char SOFT_ID_BASE_LOW  = 0xFAU;
+
+const unsigned char SOFT_ID_LENGTH = 8U;
+
+static unsigned char softIdMultiply(unsigned char a, unsigned char b)
+{
+	unsigned char result = 0x00U;
+
+	while (b != 0x00U) {
+		if ((b & 0x01U) == 0x01U)
+			result ^= a;
+
+		b >>= 1;
+
+		bool overflow = (a & 0x80U) == 0x80U;
+		a <<= 1;
+
+		if (overflow)
+			a ^= 0x1DU;
+	}
+
+	return result;
+}
+
+CP25Control::CP25Control(unsigned int nac, unsigned int id, bool selfOnly, bool uidOverride, CP25Network* network, unsigned int timeout, bool duplex, CDMRLookup* lookup, bool remoteGateway, bool softId, CRSSIInterpolator* rssiMapper) :
 m_nac(nac),
 m_id(id),
 m_selfOnly(selfOnly),
@@ -72,6 +108,9 @@ m_rfData(),
 m_netData(),
 m_rfLSD(),
 m_netLSD(),
+m_softIdEnabled(softId),
+m_softId(),
+m_softIdPtr(0U),
 m_netLDU1(nullptr),
 m_netLDU2(nullptr),
 m_lastIMBE(nullptr),
@@ -108,6 +147,8 @@ m_enabled(true)
 
 	m_rfPDU = new unsigned char[P25_MAX_PDU_COUNT * P25_LDU_FRAME_LENGTH_BYTES + 2U];
 	::memset(m_rfPDU, 0x00U, P25_MAX_PDU_COUNT * P25_LDU_FRAME_LENGTH_BYTES + 2U);
+
+	setSoftId("");
 }
 
 CP25Control::~CP25Control()
@@ -1056,6 +1097,9 @@ void CP25Control::createNetHeader()
 	m_netFrames = 0U;
 	m_netLost = 0U;
 
+	if (m_softIdEnabled)
+		setSoftId(source);
+
 	unsigned char buffer[P25_HDR_FRAME_LENGTH_BYTES + 2U];
 	::memset(buffer, 0x00U, P25_HDR_FRAME_LENGTH_BYTES + 2U);
 
@@ -1083,6 +1127,48 @@ void CP25Control::createNetHeader()
 		addBusyBits(buffer + 2U, P25_HDR_FRAME_LENGTH_BITS, false, true);
 
 	writeQueueNet(buffer, P25_HDR_FRAME_LENGTH_BYTES + 2U);
+}
+
+void CP25Control::setSoftId(const std::string& text)
+{
+	m_softId[0U] = 0x02U;
+	m_softId[1U] = SOFT_ID_LENGTH;
+
+	unsigned char high = SOFT_ID_BASE_HIGH;
+	unsigned char low  = SOFT_ID_BASE_LOW;
+
+	for (unsigned int i = 0U; i < SOFT_ID_LENGTH; i++) {
+		unsigned char c = i < text.length() ? (unsigned char)text.at(i) : ' ';
+
+		if (c >= 'a' && c <= 'z')
+			c -= 32U;
+
+		// Anything outside printable ASCII would be rejected by the radio.
+		if (c < 0x20U || c > 0x7EU)
+			c = ' ';
+
+		m_softId[i + 2U] = c;
+
+		unsigned char delta = c ^ ' ';
+		high ^= softIdMultiply(SOFT_ID_WEIGHT_HIGH[i], delta);
+		low  ^= softIdMultiply(SOFT_ID_WEIGHT_LOW[i], delta);
+	}
+
+	m_softId[10U] = high;
+	m_softId[11U] = low;
+
+	m_softIdPtr = 0U;
+}
+
+void CP25Control::addSoftId()
+{
+	if (m_softIdPtr >= sizeof(m_softId))
+		m_softIdPtr = 0U;
+
+	m_netLSD.setLSD1(m_softId[m_softIdPtr + 0U]);
+	m_netLSD.setLSD2(m_softId[m_softIdPtr + 1U]);
+
+	m_softIdPtr += 2U;
 }
 
 void CP25Control::createNetLDU1()
@@ -1116,8 +1202,12 @@ void CP25Control::createNetLDU1()
 	m_audio.encode(buffer + 2U, m_netLDU1 + 204U, 8U);
 
 	// Add the Low Speed Data
-	m_netLSD.setLSD1(m_netLDU1[201U]);
-	m_netLSD.setLSD2(m_netLDU1[202U]);
+	if (m_softIdEnabled) {
+		addSoftId();
+	} else {
+		m_netLSD.setLSD1(m_netLDU1[201U]);
+		m_netLSD.setLSD2(m_netLDU1[202U]);
+	}
 	m_netLSD.encode(buffer + 2U);
 
 	// Add busy bits
@@ -1169,8 +1259,12 @@ void CP25Control::createNetLDU2()
 	m_audio.encode(buffer + 2U, m_netLDU2 + 204U, 8U);
 
 	// Add the Low Speed Data
-	m_netLSD.setLSD1(m_netLDU2[201U]);
-	m_netLSD.setLSD2(m_netLDU2[202U]);
+	if (m_softIdEnabled) {
+		addSoftId();
+	} else {
+		m_netLSD.setLSD1(m_netLDU2[201U]);
+		m_netLSD.setLSD2(m_netLDU2[202U]);
+	}
 	m_netLSD.encode(buffer + 2U);
 
 	// Add busy bits

--- a/P25Control.h
+++ b/P25Control.h
@@ -40,7 +40,7 @@
 
 class CP25Control {
 public:
-	CP25Control(unsigned int nac, unsigned int id, bool selfOly, bool uidOverride, CP25Network* network, unsigned int timeout, bool duplex, CDMRLookup* lookup, bool remoteGateway, CRSSIInterpolator* rssiMapper);
+	CP25Control(unsigned int nac, unsigned int id, bool selfOly, bool uidOverride, CP25Network* network, unsigned int timeout, bool duplex, CDMRLookup* lookup, bool remoteGateway, bool softId, CRSSIInterpolator* rssiMapper);
 	~CP25Control();
 
 	bool writeModem(unsigned char* data, unsigned int len);
@@ -84,6 +84,9 @@ private:
 	CP25Data                   m_netData;
 	CP25LowSpeedData           m_rfLSD;
 	CP25LowSpeedData           m_netLSD;
+	bool                       m_softIdEnabled;
+	unsigned char              m_softId[12U];
+	unsigned int               m_softIdPtr;
 	unsigned char*             m_netLDU1;
 	unsigned char*             m_netLDU2;
 	unsigned char*             m_lastIMBE;
@@ -115,6 +118,9 @@ private:
 	void checkNetLDU2();
 
 	void insertMissingAudio(unsigned char* data);
+
+	void setSoftId(const std::string& text);
+	void addSoftId();
 
 	void createRFHeader();
 


### PR DESCRIPTION
Motorola radios display an eight character alias carried in the P25 low speed data, which Motorola calls Soft ID. Sending it lets a hotspot put the caller's callsign on the screen of a receiving radio instead of a bare numeric id.

Off by default, enabled with `SoftId=1` in the `[P25]` section.

![An APX showing a callsign sent by the hotspot](https://raw.githubusercontent.com/sinty/p25-motorola-soft-id/master/docs/apx-soft-id.jpg)

An incoming network call on a Motorola APX. `YL3IM` is the caller, sent by the hotspot in the low speed data and resolved through the existing id lookup. The line below it is the separate unit id field, which has no alias for that numeric id.

### Frame format

Opcode `0x02`, length `0x08`, eight space padded ASCII characters, then a two byte checksum. Two bytes go out per LDU, so one cycle spans six LDUs and repeats for the length of the transmission. The checksum is validated by the radio, which silently discards a frame carrying a wrong one.

### Checksum

Not a CRC-16 — a search over all 65536 polynomials with every combination of input and output reflection, byte order and initial value finds nothing that fits.

It is two GF(256) lanes modulo `x^8 + x^4 + x^3 + x^2 + 1`, with one weight per character position, accumulated onto the value for an all spaces string. The weights and that base value were measured off air from an APX transmitting its own Soft ID, then verified against a sample that was deliberately held back from the fit.

### Testing

Developed and run on air on a WPSD hotspot against a Motorola APX with CPS R33, first on the local parrot and then on live traffic from other stations.

The display was verified to be driven from the air rather than from the radio's own configuration: with one string programmed into the radio, the hotspot transmitted a different one, and the transmitted string is what appeared on the screen.

This branch is that change ported to `master` and compiled clean with `-Wall`, but `master` itself has not been run on air — the on air work was done on a build from `v1.0`, which is what the hotspot distributions currently ship.

### Notes

The callsign comes from the existing lookup, so an unknown id falls back to its digits, which is still more useful than nothing.

Working notes, the full set of off air samples and the tools used to derive the checksum are here: https://github.com/sinty/p25-motorola-soft-id
